### PR TITLE
Remove VALIDATION from docs

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -155,11 +155,10 @@ The following issues were identified while reviewing the current code base.
      │   └── style.css
      ├── templates
      │   └── index.html  # (optional for Jinja2 template rendering)
-     ├── README.md
-     ├── ROADMAP.md
-     └── VALIDATION.md
-     ```
-     【F:README.md†L20-L28】
+    ├── README.md
+    └── ROADMAP.md
+    ```
+    【F:README.md†L18-L27】
 
 17. **README storage path inconsistent with code**
    - Documentation claims entries are stored in `/journals/YYYY/YYYY-MM-DD.md`, but `save_entry` actually writes to `/journals/<date>.md` with no year subfolder.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Minimalist, mobile-first journaling webapp designed for personal use with Docker
 ├── templates
 │   └── index.html  # (optional for Jinja2 template rendering)
 ├── README.md
-├── ROADMAP.md
-└── VALIDATION.md
+└── ROADMAP.md
 ```
 
 ## Setup instructions


### PR DESCRIPTION
## Summary
- remove `VALIDATION.md` from the project structure in README
- update BUGS listing to match the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687cd5fae68c83329092b2924e3aa89c