### PR TITLE
Configure NAS path with variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Minimalist, mobile-first journaling webapp designed for personal use with Docker
    Ensure you have Docker and Docker Compose installed.
 
 2. **NAS journal storage**
-   Adjust `docker-compose.yml` if your NAS path differs. Example:
+   The NAS location can be configured with the `JOURNALS_DIR` environment
+   variable used in `docker-compose.yml`. Example:
    ```yaml
    volumes:
-     - /mnt/nas/journals:/journals
+     - ${JOURNALS_DIR:-/mnt/nas/journals}:/journals
    ```
 
 3. **Build and run**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     volumes:
       - ./static:/app/static
       - ./prompts.json:/app/prompts.json
-      - /mnt/Movies-And-More/journals:/journals
+      - ${JOURNALS_DIR:-/mnt/nas/journals}:/journals
     environment:
       - TZ=America/New_York


### PR DESCRIPTION
## Summary
- parameterize journal storage path in `docker-compose.yml`
- document the `JOURNALS_DIR` variable in the setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cda444c8c8332b6d66e9628ba529e