### PR TITLE
Fix get_season date usage

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -2,15 +2,14 @@
 
 The following issues were identified while reviewing the current code base.
 
-1. **Invalid call to `datetime.date`**
-   - `get_season` tries to use `datetime.date` even though `datetime` was imported as the `datetime` class, not the module. This raises a `TypeError` at runtime.
-   - Lines showing the issue:
+1. **Invalid call to `datetime.date`** (fixed)
+   - `get_season` previously used `datetime.date` even though `datetime` was imported as the `datetime` class. The code now correctly calls the `date` constructor.
+   - Fixed lines:
      ```python
-     def get_season(date):
-         Y = date.year
-         if date >= datetime.date(Y, 3, 1) and date < datetime.date(Y, 6, 1):
+     spring_start = date(year, 3, 1)
+     summer_start = date(year, 6, 1)
      ```
-     【F:main.py†L110-L118】
+     【F:main.py†L121-L125】
 
 2. **Duplicate `PROMPTS_FILE` constant**
    - `PROMPTS_FILE` is defined twice in `main.py` (lines 13 and 85). The second definition is redundant.

--- a/main.py
+++ b/main.py
@@ -119,10 +119,10 @@ def generate_prompt():
 def get_season(target_date):
     """Return the season name for the given date."""
     year = target_date.year
-    spring_start = datetime.date(year, 3, 1)
-    summer_start = datetime.date(year, 6, 1)
-    autumn_start = datetime.date(year, 9, 1)
-    winter_start = datetime.date(year, 12, 1)
+    spring_start = date(year, 3, 1)
+    summer_start = date(year, 6, 1)
+    autumn_start = date(year, 9, 1)
+    winter_start = date(year, 12, 1)
 
     if spring_start <= target_date < summer_start:
         return "Spring"


### PR DESCRIPTION
## Summary
- avoid calling `datetime.date` in `get_season`
- mark bug 1 as fixed in BUGS.md

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce744593c833285e997a732b550c0