### PR TITLE
Add tests covering HTTP endpoints

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,95 @@
+import shutil
+from pathlib import Path
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Prepare required directories before importing the app
+ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = Path('/app')
+STATIC_DIR = APP_DIR / 'static'
+PROMPTS_FILE = APP_DIR / 'prompts.json'
+DATA_ROOT = Path('/journals')
+
+STATIC_DIR.mkdir(parents=True, exist_ok=True)
+DATA_ROOT.mkdir(parents=True, exist_ok=True)
+# copy prompts file if not already
+if not PROMPTS_FILE.exists():
+    shutil.copy(ROOT / 'prompts.json', PROMPTS_FILE)
+
+# Import the application after environment setup
+import main  # type: ignore
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    journals = tmp_path / 'journals'
+    journals.mkdir()
+    monkeypatch.setattr(main, 'DATA_DIR', journals)
+    return TestClient(main.app)
+
+
+def test_index_returns_page(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert 'Echo Journal' in resp.text
+
+
+def test_save_entry_and_retrieve(client):
+    payload = {'date': '2020-01-01', 'content': 'entry', 'prompt': 'prompt'}
+    resp = client.post('/entry', json=payload)
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'success'
+    file_path = main.DATA_DIR / '2020-01-01.md'
+    assert file_path.exists()
+    resp2 = client.get('/entry/2020-01-01')
+    assert resp2.status_code == 200
+    assert 'prompt' in resp2.json()['content']
+
+
+def test_save_entry_missing_fields(client):
+    resp = client.post('/entry', json={'date': '2020-01-02'})
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'error'
+
+
+def test_get_entry_not_found(client):
+    resp = client.get('/entry/1999-01-01')
+    assert resp.status_code == 404
+
+
+def test_load_entry(client):
+    (main.DATA_DIR / '2020-02-02.md').write_text('# Prompt\nA\n\n# Entry\nB', encoding='utf-8')
+    resp = client.get('/entry', params={'entry_date': '2020-02-02'})
+    assert resp.status_code == 200
+    assert resp.json()['content'] == 'B'
+
+
+def test_load_entry_missing(client):
+    resp = client.get('/entry', params={'entry_date': '2000-01-01'})
+    assert resp.status_code == 404
+
+
+def test_view_entry_existing(client):
+    (main.DATA_DIR / '2020-03-03.md').write_text('# Prompt\nA\n\n# Entry\nB', encoding='utf-8')
+    resp = client.get('/view/2020-03-03')
+    assert resp.status_code == 200
+    assert 'B' in resp.text
+    assert 'readonly' in resp.text
+
+
+def test_view_entry_missing(client):
+    resp = client.get('/view/2020-04-04')
+    assert resp.status_code == 200
+
+
+def test_archive_view(client):
+    (main.DATA_DIR / '2020-05-01.md').write_text('# Prompt\nP\n\n# Entry\nE1', encoding='utf-8')
+    (main.DATA_DIR / '2020-05-02.md').write_text('# Prompt\nP\n\n# Entry\nE2', encoding='utf-8')
+    (main.DATA_DIR / 'badfile.md').write_text('oops', encoding='utf-8')
+    resp = client.get('/archive')
+    assert resp.status_code == 200
+    assert '2020-05-01' in resp.text
+    assert '2020-05-02' in resp.text
+    assert 'badfile' not in resp.text


### PR DESCRIPTION
## Summary
- create `tests/` with unit tests for all FastAPI endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d009186688332a3848bb014c9b4b8