### PR TITLE
Enhance accessibility and add settings page

### DIFF
--- a/main.py
+++ b/main.py
@@ -193,6 +193,13 @@ async def view_entry(request: Request, entry_date: str):
             "content": entry,
             "date": entry_date,
             "prompt": prompt,
-            "readonly": True  # Read-only mode for archive
+        "readonly": True  # Read-only mode for archive
         }
     )
+
+
+@app.get("/settings", response_class=HTMLResponse)
+async def settings_page(request: Request):
+    """Render the user settings page."""
+    return templates.TemplateResponse("settings.html", {"request": request})
+

--- a/static/style.css
+++ b/static/style.css
@@ -274,3 +274,27 @@ a:visited {
     color: #60a5fa; /* blue-400 for dark mode (brighter, readable) */
   }
 }
+
+/* Screen reader only helper */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Keyboard focus outline */
+:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+/* Error text */
+.error-text {
+  color: #dc2626; /* red-600 */
+}

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -5,7 +5,10 @@
 {% block content %}
 <header class="flex justify-between items-center w-full max-w-md mx-auto mb-2">
   <h1 id="welcome-message" class="welcome-message">Archive</h1>
-  <a href="/" class="text-sm link-style">Home</a>
+  <nav class="space-x-4 text-sm" aria-label="Archive navigation">
+    <a href="/" class="link-style">Home</a>
+    <a href="/settings" class="link-style">Settings</a>
+  </nav>
 </header>
 
 <p class="text-sm text-muted mt-1 mb-4 text-center">

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -15,12 +15,13 @@
   </h1>
 </div>
 
-  <nav class="space-x-4 text-sm">
+  <nav class="space-x-4 text-sm" aria-label="Main navigation">
     {% if readonly %}
       <a href="/" class="text-blue-300 hover:underline">Home</a>
     {% else %}
       <a href="/archive" class="text-blue-300 hover:underline">View Archive</a>
     {% endif %}
+    <a href="/settings" class="text-blue-300 hover:underline">Settings</a>
   </nav>
 </header>
   <section class="w-full max-w-md space-y-4 text-center">
@@ -30,21 +31,22 @@
     </div>
   </section>
 
-  <section class="w-full max-w-md mt-4 justify-center">
-    <textarea id="journal-text" class="journal-textarea justify-center"
-      placeholder="Write freely… describe what happened, how you felt, what you noticed, or anything else that stands out."
-      {% if readonly %}readonly{% endif %}
-      oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
-      rows="4"
-    >{{ content }}</textarea>
-  </section>
+<section class="w-full max-w-md mt-4 justify-center">
+  <label for="journal-text" class="sr-only">Journal entry</label>
+  <textarea id="journal-text" class="journal-textarea justify-center"
+    placeholder="Write freely… describe what happened, how you felt, what you noticed, or anything else that stands out."
+    {% if readonly %}readonly{% endif %}
+    oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
+    rows="4"
+  >{{ content }}</textarea>
+</section>
     {% if not readonly %}
   <section class="w-full max-w-md mt-6">
-    <button id="save-button" class="save-button">Save Entry</button>
+    <button id="save-button" class="save-button" aria-label="Save entry">Save Entry</button>
   </section>
     {% endif %}
 
-  <footer class="w-full max-w-md mt-8 footer-text" id="save-status">
+  <footer class="w-full max-w-md mt-8 footer-text" id="save-status" aria-live="polite" role="status">
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="logo-inline">
   {% if content %}Last saved: loaded from file{% else %}Last saved: no entry yet{% endif %} — Echo Journal
   </footer>
@@ -92,12 +94,23 @@ if (saveButton) {
     const result = await response.json();
     const status = document.getElementById('save-status');
     if (result.status === "success") {
-      status.innerHTML = "<p>Last saved: just now</p>";
+      status.textContent = "Last saved: just now — Echo Journal";
+      status.classList.remove('error-text');
     } else {
-      status.innerHTML = "<p>Save failed</p>";
+      status.textContent = "Save failed. Please try again.";
+      status.classList.add('error-text');
     }
   });
 }
+
+document.addEventListener('keydown', (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+    e.preventDefault();
+    if (saveButton) {
+      saveButton.click();
+    }
+  }
+});
 
   </script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}Settings - Echo Journal{% endblock %}
+
+{% block content %}
+<header class="flex justify-between items-center w-full max-w-md mx-auto mb-4">
+  <h1 id="welcome-message" class="welcome-message">Settings</h1>
+  <nav class="space-x-4 text-sm" aria-label="Settings navigation">
+    <a href="/" class="link-style">Home</a>
+    <a href="/archive" class="link-style">Archive</a>
+  </nav>
+</header>
+
+<p class="text-sm text-muted text-center mb-4">
+  Adjust your preferences below. Changes are saved locally in your browser.
+</p>
+
+<form class="space-y-4" aria-label="Settings form">
+  <label for="dark-toggle" class="flex items-center space-x-2">
+    <input type="checkbox" id="dark-toggle">
+    <span>Use dark mode</span>
+  </label>
+</form>
+
+<footer class="w-full max-w-md mt-8 footer-text">
+  <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="logo-inline">
+  Echo Journal
+</footer>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("welcome-message");
+  if (el) {
+    requestAnimationFrame(() => {
+      el.style.opacity = 1;
+    });
+  }
+  const toggle = document.getElementById('dark-toggle');
+  if (toggle) {
+    const stored = localStorage.getItem('dark-mode');
+    if (stored === 'true') {
+      toggle.checked = true;
+      document.documentElement.classList.add('dark');
+    }
+    toggle.addEventListener('change', () => {
+      if (toggle.checked) {
+        document.documentElement.classList.add('dark');
+        localStorage.setItem('dark-mode', 'true');
+      } else {
+        document.documentElement.classList.remove('dark');
+        localStorage.setItem('dark-mode', 'false');
+      }
+    });
+  }
+});
+</script>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- expand navigation links and add settings page
- label form elements for screen readers
- improve keyboard navigation and error feedback
- tweak archive header
- add sr-only helper and focus outlines

## Testing
- `python -m py_compile main.py`
- `pip install pylint` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d00bb4cc0833294340e0212dbf3e7