### PR TITLE
Fix generate_prompt error handling

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -75,14 +75,20 @@ The following issues were identified while reviewing the current code base.
      ```
      【F:main.py†L28-L33】
 
-8. **`generate_prompt` lacks error handling**
-   - If `prompts.json` is missing or malformed, `json.loads` will raise an exception and crash the app.
-   - Consider catching `FileNotFoundError` and `JSONDecodeError`.
-   - Lines:
+8. **`generate_prompt` lacks error handling** (fixed)
+   - The function now catches `FileNotFoundError` and `JSONDecodeError` when
+     loading `prompts.json`.
+   - Updated lines:
      ```python
-     prompts = json.loads(PROMPTS_FILE.read_text())
+     try:
+         prompts_text = PROMPTS_FILE.read_text(encoding="utf-8")
+         prompts = json.loads(prompts_text)
+     except FileNotFoundError:
+         return {"category": None, "prompt": "Prompts file not found"}
+     except json.JSONDecodeError:
+         return {"category": None, "prompt": "Invalid prompts file"}
      ```
-     【F:main.py†L92-L93】
+     【F:main.py†L106-L112】
 
 9. **Missing data directory creation** (fixed)
    - `save_entry` now ensures the `/journals` folder exists before writing.

--- a/main.py
+++ b/main.py
@@ -103,7 +103,13 @@ def generate_prompt():
     weekday = today.strftime("%A")
     season = get_season(today)
 
-    prompts = json.loads(PROMPTS_FILE.read_text(encoding="utf-8"))
+    try:
+        prompts_text = PROMPTS_FILE.read_text(encoding="utf-8")
+        prompts = json.loads(prompts_text)
+    except FileNotFoundError:
+        return {"category": None, "prompt": "Prompts file not found"}
+    except json.JSONDecodeError:
+        return {"category": None, "prompt": "Invalid prompts file"}
     categories = list(prompts["categories"].keys())
 
     if not categories:


### PR DESCRIPTION
## Summary
- handle missing or malformed `prompts.json` when generating prompts
- mark bug about missing error handling in `generate_prompt` as fixed

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687d011852a88332ab3edeefbfb9a080