### PR TITLE
Fix archive subdirectory handling

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -34,13 +34,14 @@ The following issues were identified while reviewing the current code base.
      ```
      【F:main.py†L75-L83】
 
-4. **Archive function ignores subdirectories**
-   - `archive_view` scans `DATA_DIR.glob("*.md")`. If journal entries were stored in year subfolders, they would not appear in the archive.
-   - Lines:
+4. **Archive function ignores subdirectories** (fixed)
+   - `archive_view` previously scanned only the top-level `DATA_DIR` directory using `glob("*.md")`.
+     It now recursively searches with `rglob("*.md")` so entries within year folders are included.
+   - Updated lines:
      ```python
-     for file in DATA_DIR.glob("*.md"):
+     for file in DATA_DIR.rglob("*.md"):
      ```
-     【F:main.py†L121-L133】
+     【F:main.py†L150-L158】
 
 
 5. **Unsanitized date parameter allows path traversal**

--- a/main.py
+++ b/main.py
@@ -148,7 +148,9 @@ async def archive_view(request: Request):
     """Render an archive of all journal entries grouped by month."""
     entries_by_month = defaultdict(list)
 
-    for file in DATA_DIR.glob("*.md"):
+    # Recursively gather markdown files to include any entries stored in
+    # subdirectories such as year folders
+    for file in DATA_DIR.rglob("*.md"):
         try:
             entry_date = datetime.strptime(file.stem, "%Y-%m-%d").date()
         except ValueError:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -88,8 +88,12 @@ def test_archive_view(client):
     (main.DATA_DIR / '2020-05-01.md').write_text('# Prompt\nP\n\n# Entry\nE1', encoding='utf-8')
     (main.DATA_DIR / '2020-05-02.md').write_text('# Prompt\nP\n\n# Entry\nE2', encoding='utf-8')
     (main.DATA_DIR / 'badfile.md').write_text('oops', encoding='utf-8')
+    subdir = main.DATA_DIR / '2021'
+    subdir.mkdir()
+    (subdir / '2021-06-01.md').write_text('# Prompt\nP\n\n# Entry\nE3', encoding='utf-8')
     resp = client.get('/archive')
     assert resp.status_code == 200
     assert '2020-05-01' in resp.text
     assert '2020-05-02' in resp.text
+    assert '2021-06-01' in resp.text
     assert 'badfile' not in resp.text


### PR DESCRIPTION
## Summary
- search recursively when collecting journal entry files
- test archive page with entries in subfolders
- mark bug 4 as fixed in BUGS.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d0417d9b88332818e78b1207f6239