### PR TITLE
Improve async file operations and prompt caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 Jinja2>=3.0
+aiofiles


### PR DESCRIPTION
## Summary
- use `aiofiles` for reading and writing journal entries
- cache prompts in-memory with an async loader
- add `aiofiles` requirement

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d0689468083329e35c2879f12ad38