### PR TITLE
Fix view entry 404 handling

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -81,7 +81,7 @@ def test_view_entry_existing(client):
 
 def test_view_entry_missing(client):
     resp = client.get('/view/2020-04-04')
-    assert resp.status_code == 200
+    assert resp.status_code == 404
 
 
 def test_archive_view(client):
@@ -125,4 +125,4 @@ def test_get_entry_invalid_date(client):
 
 def test_view_entry_traversal(client):
     resp = client.get('/view/../../etc/passwd')
-    assert resp.status_code == 200
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- raise `HTTPException(404)` when an entry is missing in `/view/{entry_date}`
- update tests for 404 responses on missing or invalid view requests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d0ba8bc24833284e1c1475a436edc