### PR TITLE
Silence pylint fixture warnings

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,5 +1,11 @@
 """Endpoint tests for the Echo Journal application."""
 
+# Disable fixture name shadowing warnings in test functions.
+# pytest expects tests to accept the ``test_client`` fixture as an argument,
+# which triggers ``redefined-outer-name`` from pylint.
+#
+# pylint: disable=redefined-outer-name
+
 import shutil
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- silence pylint warnings in `tests/test_endpoints.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_687d0e505dbc83329c5272b2934cbfc4