### PR TITLE
Add AGENTS instructions and format code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Codex Agent Guidelines
+
+This file outlines how the Codex agent should interact with the Echo Journal repository.
+The instructions apply to the entire project tree.
+
+## Development setup
+1. Create a virtual environment and install dependencies:
+   ```sh
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+   You may also run the app with Docker using `docker-compose up --build`.
+
+## Style and testing
+- Format all Python code with **Black**.
+- Run **Pylint** with a minimum score of 8:
+  ```sh
+  pylint $(git ls-files '*.py') --fail-under=8
+  ```
+- Execute the test suite with **pytest**.
+- Ensure `black`, `pylint` and `pytest` succeed before committing changes.
+
+## Commit and PR guidelines
+- Make small, focused commits with clear messages.
+- Open pull requests against `main` after all checks pass.
+- Summaries should briefly explain what changed and reference key files.
+

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ def safe_entry_path(entry_date: str) -> Path:
         raise ValueError("Invalid entry date") from exc
     return path
 
+
 @app.get("/")
 async def index(request: Request):
     """Render the journal entry page for the current day."""
@@ -56,7 +57,9 @@ async def index(request: Request):
     if file_path.exists():
         async with aiofiles.open(file_path, "r", encoding="utf-8") as fh:
             md_content = await fh.read()
-        prompt_part = md_content.split("# Prompt\n", 1)[1].split("\n\n# Entry\n", 1)[0].strip()
+        prompt_part = (
+            md_content.split("# Prompt\n", 1)[1].split("\n\n# Entry\n", 1)[0].strip()
+        )
         entry_part = md_content.split("# Entry\n", 1)[1].strip()
         prompt = prompt_part
         entry = entry_part
@@ -65,14 +68,18 @@ async def index(request: Request):
         prompt = prompt_data["prompt"]
         entry = ""
 
-    return templates.TemplateResponse("echo_journal.html", {
-        "request": request,
-        "prompt": prompt,
-        "category": "",  # Optionally store saved category or leave blank for saved entries
-        "date": date_str,
-        "content": entry,
-        "readonly": False  # Explicit
-    })
+    return templates.TemplateResponse(
+        "echo_journal.html",
+        {
+            "request": request,
+            "prompt": prompt,
+            "category": "",  # Optionally store saved category or leave blank for saved entries
+            "date": date_str,
+            "content": entry,
+            "readonly": False,  # Explicit
+        },
+    )
+
 
 @app.post("/entry")
 async def save_entry(data: dict):
@@ -111,6 +118,7 @@ async def get_entry(entry_date: str):
         }
     return JSONResponse(status_code=404, content={"error": "Entry not found"})
 
+
 @app.get("/entry")
 async def load_entry(entry_date: str):
     """Load the textual content for an entry without headers."""
@@ -123,7 +131,6 @@ async def load_entry(entry_date: str):
         entry_text = parts[1].strip() if len(parts) > 1 else ""
         return {"status": "success", "content": entry_text}
     return JSONResponse(status_code=404, content={"status": "not_found", "content": ""})
-
 
 
 async def load_prompts():
@@ -158,12 +165,18 @@ async def generate_prompt():
 
     candidates = prompts["categories"].get(category, [])
     if not candidates:
-        return {"category": category.capitalize(), "prompt": "No prompts in this category"}
+        return {
+            "category": category.capitalize(),
+            "prompt": "No prompts in this category",
+        }
 
     prompt_template = random.choice(candidates)
-    prompt = prompt_template.replace("{{weekday}}", weekday).replace("{{season}}", season)
+    prompt = prompt_template.replace("{{weekday}}", weekday).replace(
+        "{{season}}", season
+    )
 
     return {"category": category.capitalize(), "prompt": prompt}
+
 
 def get_season(target_date):
     """Return the season name for the given date."""
@@ -180,6 +193,7 @@ def get_season(target_date):
     if autumn_start <= target_date < winter_start:
         return "Autumn"
     return "Winter"
+
 
 @app.get("/archive", response_class=HTMLResponse)
 async def archive_view(request: Request):
@@ -202,10 +216,10 @@ async def archive_view(request: Request):
     # Sort months descending (latest first)
     sorted_entries = dict(sorted(entries_by_month.items(), reverse=True))
 
-    return templates.TemplateResponse("archives.html", {
-        "request": request,
-        "entries": sorted_entries
-    })
+    return templates.TemplateResponse(
+        "archives.html", {"request": request, "entries": sorted_entries}
+    )
+
 
 @app.get("/view/{entry_date}")
 async def view_entry(request: Request, entry_date: str):
@@ -250,8 +264,8 @@ async def view_entry(request: Request, entry_date: str):
             "content": entry,
             "date": entry_date,
             "prompt": prompt,
-        "readonly": True  # Read-only mode for archive
-        }
+            "readonly": True,  # Read-only mode for archive
+        },
     )
 
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -14,16 +14,16 @@ from fastapi.testclient import TestClient  # pylint: disable=import-error
 
 # Prepare required directories before importing the app
 ROOT = Path(__file__).resolve().parents[1]
-APP_DIR = Path('/app')
-STATIC_DIR = APP_DIR / 'static'
-PROMPTS_FILE = APP_DIR / 'prompts.json'
-DATA_ROOT = Path('/journals')
+APP_DIR = Path("/app")
+STATIC_DIR = APP_DIR / "static"
+PROMPTS_FILE = APP_DIR / "prompts.json"
+DATA_ROOT = Path("/journals")
 
 STATIC_DIR.mkdir(parents=True, exist_ok=True)
 DATA_ROOT.mkdir(parents=True, exist_ok=True)
 # copy prompts file if not already
 if not PROMPTS_FILE.exists():
-    shutil.copy(ROOT / 'prompts.json', PROMPTS_FILE)
+    shutil.copy(ROOT / "prompts.json", PROMPTS_FILE)
 
 # Import the application after environment setup
 import main  # type: ignore  # pylint: disable=wrong-import-position
@@ -32,133 +32,144 @@ import main  # type: ignore  # pylint: disable=wrong-import-position
 @pytest.fixture()
 def test_client(tmp_path, monkeypatch):
     """Return a TestClient instance using a temporary journals directory."""
-    journals = tmp_path / 'journals'
+    journals = tmp_path / "journals"
     journals.mkdir()
-    monkeypatch.setattr(main, 'DATA_DIR', journals)
+    monkeypatch.setattr(main, "DATA_DIR", journals)
     return TestClient(main.app)
 
 
 def test_index_returns_page(test_client):
     """Requesting the index should return the journal page."""
-    resp = test_client.get('/')
+    resp = test_client.get("/")
     assert resp.status_code == 200
-    assert 'Echo Journal' in resp.text
+    assert "Echo Journal" in resp.text
 
 
 def test_save_entry_and_retrieve(test_client):
     """Entries can be saved and later retrieved."""
-    payload = {'date': '2020-01-01', 'content': 'entry', 'prompt': 'prompt'}
-    resp = test_client.post('/entry', json=payload)
+    payload = {"date": "2020-01-01", "content": "entry", "prompt": "prompt"}
+    resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    assert resp.json()['status'] == 'success'
-    file_path = main.DATA_DIR / '2020-01-01.md'
+    assert resp.json()["status"] == "success"
+    file_path = main.DATA_DIR / "2020-01-01.md"
     assert file_path.exists()
-    resp2 = test_client.get('/entry/2020-01-01')
+    resp2 = test_client.get("/entry/2020-01-01")
     assert resp2.status_code == 200
-    assert 'prompt' in resp2.json()['content']
+    assert "prompt" in resp2.json()["content"]
 
 
 def test_save_entry_missing_fields(test_client):
     """Saving with missing required fields should return an error."""
-    resp = test_client.post('/entry', json={'date': '2020-01-02'})
+    resp = test_client.post("/entry", json={"date": "2020-01-02"})
     assert resp.status_code == 200
-    assert resp.json()['status'] == 'error'
+    assert resp.json()["status"] == "error"
 
 
 def test_get_entry_not_found(test_client):
     """Fetching a non-existent entry should return 404."""
-    resp = test_client.get('/entry/1999-01-01')
+    resp = test_client.get("/entry/1999-01-01")
     assert resp.status_code == 404
 
 
 def test_load_entry(test_client):
     """load_entry endpoint should return the entry text without headers."""
-    (main.DATA_DIR / '2020-02-02.md').write_text('# Prompt\nA\n\n# Entry\nB', encoding='utf-8')
-    resp = test_client.get('/entry', params={'entry_date': '2020-02-02'})
+    (main.DATA_DIR / "2020-02-02.md").write_text(
+        "# Prompt\nA\n\n# Entry\nB", encoding="utf-8"
+    )
+    resp = test_client.get("/entry", params={"entry_date": "2020-02-02"})
     assert resp.status_code == 200
-    assert resp.json()['content'] == 'B'
+    assert resp.json()["content"] == "B"
 
 
 def test_load_entry_missing(test_client):
     """Loading a missing entry should return 404."""
-    resp = test_client.get('/entry', params={'entry_date': '2000-01-01'})
+    resp = test_client.get("/entry", params={"entry_date": "2000-01-01"})
     assert resp.status_code == 404
 
 
 def test_view_entry_existing(test_client):
     """Existing entries can be viewed in read-only mode."""
-    (main.DATA_DIR / '2020-03-03.md').write_text('# Prompt\nA\n\n# Entry\nB', encoding='utf-8')
-    resp = test_client.get('/view/2020-03-03')
+    (main.DATA_DIR / "2020-03-03.md").write_text(
+        "# Prompt\nA\n\n# Entry\nB", encoding="utf-8"
+    )
+    resp = test_client.get("/view/2020-03-03")
     assert resp.status_code == 200
-    assert 'B' in resp.text
-    assert 'readonly' in resp.text
+    assert "B" in resp.text
+    assert "readonly" in resp.text
 
 
 def test_view_entry_multiline_prompt(test_client):
     """Prompts spanning multiple lines should render correctly."""
-    content = '# Prompt\nLine1\nLine2\n\n# Entry\nBody'
-    (main.DATA_DIR / '2020-03-04.md').write_text(content, encoding='utf-8')
-    resp = test_client.get('/view/2020-03-04')
+    content = "# Prompt\nLine1\nLine2\n\n# Entry\nBody"
+    (main.DATA_DIR / "2020-03-04.md").write_text(content, encoding="utf-8")
+    resp = test_client.get("/view/2020-03-04")
     assert resp.status_code == 200
-    assert 'Line1' in resp.text and 'Line2' in resp.text
-    assert 'Body' in resp.text
+    assert "Line1" in resp.text and "Line2" in resp.text
+    assert "Body" in resp.text
 
 
 def test_view_entry_malformed(test_client):
     """Malformed files trigger a server error."""
-    (main.DATA_DIR / 'bad.md').write_text('No headings here', encoding='utf-8')
-    resp = test_client.get('/view/bad')
+    (main.DATA_DIR / "bad.md").write_text("No headings here", encoding="utf-8")
+    resp = test_client.get("/view/bad")
     assert resp.status_code == 500
 
 
 def test_view_entry_missing(test_client):
     """Requesting a missing entry by date returns 404."""
-    resp = test_client.get('/view/2020-04-04')
+    resp = test_client.get("/view/2020-04-04")
     assert resp.status_code == 404
 
 
 def test_archive_view(test_client):
     """The archive page lists all valid entries."""
-    (main.DATA_DIR / '2020-05-01.md').write_text('# Prompt\nP\n\n# Entry\nE1', encoding='utf-8')
-    (main.DATA_DIR / '2020-05-02.md').write_text('# Prompt\nP\n\n# Entry\nE2', encoding='utf-8')
-    (main.DATA_DIR / 'badfile.md').write_text('oops', encoding='utf-8')
-    subdir = main.DATA_DIR / '2021'
+    (main.DATA_DIR / "2020-05-01.md").write_text(
+        "# Prompt\nP\n\n# Entry\nE1", encoding="utf-8"
+    )
+    (main.DATA_DIR / "2020-05-02.md").write_text(
+        "# Prompt\nP\n\n# Entry\nE2", encoding="utf-8"
+    )
+    (main.DATA_DIR / "badfile.md").write_text("oops", encoding="utf-8")
+    subdir = main.DATA_DIR / "2021"
     subdir.mkdir()
-    (subdir / '2021-06-01.md').write_text('# Prompt\nP\n\n# Entry\nE3', encoding='utf-8')
-    resp = test_client.get('/archive')
+    (subdir / "2021-06-01.md").write_text(
+        "# Prompt\nP\n\n# Entry\nE3", encoding="utf-8"
+    )
+    resp = test_client.get("/archive")
     assert resp.status_code == 200
-    assert '2020-05-01' in resp.text
-    assert '2020-05-02' in resp.text
-    assert '2021-06-01' in resp.text
-    assert 'badfile' not in resp.text
+    assert "2020-05-01" in resp.text
+    assert "2020-05-02" in resp.text
+    assert "2021-06-01" in resp.text
+    assert "badfile" not in resp.text
+
 
 def test_save_entry_invalid_date(test_client):
     """Entries with malformed date strings are still saved as-is."""
-    payload = {'date': '2020-13-40', 'content': 'bad', 'prompt': 'p'}
-    resp = test_client.post('/entry', json=payload)
+    payload = {"date": "2020-13-40", "content": "bad", "prompt": "p"}
+    resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    assert resp.json()['status'] == 'success'
-    assert (main.DATA_DIR / '2020-13-40.md').exists()
+    assert resp.json()["status"] == "success"
+    assert (main.DATA_DIR / "2020-13-40.md").exists()
 
 
 def test_save_entry_path_traversal(test_client):
     """Attempting directory traversal should only affect paths inside DATA_DIR."""
-    malicious = '../malicious'
-    payload = {'date': malicious, 'content': 'x', 'prompt': 'y'}
-    resp = test_client.post('/entry', json=payload)
+    malicious = "../malicious"
+    payload = {"date": malicious, "content": "x", "prompt": "y"}
+    resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    expected = main.DATA_DIR / 'malicious.md'
+    expected = main.DATA_DIR / "malicious.md"
     assert expected.exists()
     assert expected.resolve().is_relative_to(main.DATA_DIR.resolve())
 
 
 def test_get_entry_invalid_date(test_client):
     """Invalid date segments should yield a 404 response."""
-    resp = test_client.get('/entry/invalid-date')
+    resp = test_client.get("/entry/invalid-date")
     assert resp.status_code == 404
 
 
 def test_view_entry_traversal(test_client):
     """Path traversal attempts in view routes should be denied."""
-    resp = test_client.get('/view/../../etc/passwd')
+    resp = test_client.get("/view/../../etc/passwd")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- provide Codex agent guidelines
- format Python files with Black

## Testing
- `black --check .`
- `pylint $(git ls-files '*.py') --fail-under=8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d2d7820c483329e72437c3da23ff3