### PR TITLE
Refactor navigation header

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,7 +93,8 @@ async def index(request: Request):
         "category": "",  # Optionally store saved category or leave blank for saved entries
         "date": date_str,
         "content": entry,
-        "readonly": False  # Explicit
+        "readonly": False,  # Explicit
+        "active_page": "home",
     })
 
 @app.post("/entry")
@@ -226,7 +227,8 @@ async def archive_view(request: Request):
 
     return templates.TemplateResponse("archives.html", {
         "request": request,
-        "entries": sorted_entries
+        "entries": sorted_entries,
+        "active_page": "archive",
     })
 
 @app.get("/view/{entry_date}")
@@ -252,7 +254,8 @@ async def view_entry(request: Request, entry_date: str):
             "content": entry,
             "date": entry_date,
             "prompt": prompt,
-        "readonly": True  # Read-only mode for archive
+            "readonly": True,  # Read-only mode for archive
+            "active_page": "archive",
         }
     )
 
@@ -260,4 +263,7 @@ async def view_entry(request: Request, entry_date: str):
 @app.get("/settings", response_class=HTMLResponse)
 async def settings_page(request: Request):
     """Render the user settings page."""
-    return templates.TemplateResponse("settings.html", {"request": request})
+    return templates.TemplateResponse(
+        "settings.html",
+        {"request": request, "active_page": "settings"},
+    )

--- a/static/style.css
+++ b/static/style.css
@@ -269,6 +269,17 @@ a:visited {
   text-decoration: underline;
 }
 
+.active-link {
+  font-weight: 600;
+}
+
+.sticky-header {
+  position: sticky;
+  top: 0;
+  background-color: inherit;
+  z-index: 10;
+}
+
 @media (prefers-color-scheme: dark) {
   .link-style {
     color: #60a5fa; /* blue-400 for dark mode (brighter, readable) */

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -2,14 +2,11 @@
 
 {% block title %}Echo Journal Archives{% endblock %}
 
-{% block content %}
-<header class="flex justify-between items-center w-full max-w-md mx-auto mb-2">
+{% block header_title %}
   <h1 id="welcome-message" class="welcome-message">Archive</h1>
-  <nav class="space-x-4 text-sm" aria-label="Archive navigation">
-    <a href="/" class="link-style">Home</a>
-    <a href="/settings" class="link-style">Settings</a>
-  </nav>
-</header>
+{% endblock %}
+
+{% block content %}
 
 <p class="text-sm text-muted mt-1 mb-4 text-center">
   A gentle record of your days — grouped for easy reflection.

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,19 @@
   <meta name="theme-color" content="#1a1a1a">
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-6">
-  {% block content %}{% endblock %}
+  <header class="flex justify-between items-center w-full max-w-md mx-auto mb-4 sticky-header">
+    {% block header_title %}
+    <h1 class="welcome-message">Echo Journal</h1>
+    {% endblock %}
+    <nav class="space-x-4 text-sm" aria-label="Main navigation">
+      <a href="/" class="link-style {% if active_page == 'home' %}active-link{% endif %}">Home</a>
+      <a href="/archive" class="link-style {% if active_page == 'archive' %}active-link{% endif %}">Archive</a>
+      <a href="/settings" class="link-style {% if active_page == 'settings' %}active-link{% endif %}">Settings</a>
+    </nav>
+  </header>
+
+  <main class="w-full max-w-md mx-auto space-y-6">
+    {% block content %}{% endblock %}
+  </main>
 </body>
 </html>

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -2,28 +2,18 @@
 
 {% block title %}Echo Journal{% endblock %}
 
-{% block content %}
-<header class="flex justify-between items-center w-full max-w-md mx-auto mb-4">
-<div class="flex items-center space-x-2">
+{% block header_title %}
   <h1 id="welcome-message" class="welcome-message"
-      {% if not readonly %} data-dynamic-greeting="true" {% endif %}>
+      {% if not readonly %} data-dynamic-greeting="true"{% endif %}>
     {% if readonly %}
       Welcome back to {{ date }}
     {% else %}
       Welcome back.
     {% endif %}
   </h1>
-</div>
+{% endblock %}
 
-  <nav class="space-x-4 text-sm" aria-label="Main navigation">
-    {% if readonly %}
-      <a href="/" class="text-blue-300 hover:underline">Home</a>
-    {% else %}
-      <a href="/archive" class="text-blue-300 hover:underline">View Archive</a>
-    {% endif %}
-    <a href="/settings" class="text-blue-300 hover:underline">Settings</a>
-  </nav>
-</header>
+{% block content %}
   <section class="w-full max-w-md space-y-4 text-center">
     <div class="prompt-section">
       <p class="prompt-text">{{ prompt }}</p>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,14 +2,11 @@
 
 {% block title %}Settings - Echo Journal{% endblock %}
 
-{% block content %}
-<header class="flex justify-between items-center w-full max-w-md mx-auto mb-4">
+{% block header_title %}
   <h1 id="welcome-message" class="welcome-message">Settings</h1>
-  <nav class="space-x-4 text-sm" aria-label="Settings navigation">
-    <a href="/" class="link-style">Home</a>
-    <a href="/archive" class="link-style">Archive</a>
-  </nav>
-</header>
+{% endblock %}
+
+{% block content %}
 
 <p class="text-sm text-muted text-center mb-4">
   Adjust your preferences below. Changes are saved locally in your browser.


### PR DESCRIPTION
## Summary
- centralize navigation in `base.html`
- show active page highlight
- make header sticky
- use the new header in all templates
- expose `active_page` from FastAPI routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d30e81058833289fc11996634179e