### PR TITLE
Clean up unused CSS

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -156,17 +156,6 @@ button.save-button:hover {
   }
 }
 
-#save-status p {
-  font-size: 0.75rem;
-  text-align: center;
-  color: #6b7280;
-  margin-top: 0.5rem;
-  display: none;
-}
-
-#save-status p.active {
-  display: block;
-}
 
 .footer-text {
   font-size: clamp(0.9rem, 0.8vw + 0.8rem, 1rem); /* match improved microcopy sizing */


### PR DESCRIPTION
## Summary
- audit templates
- drop dead `#save-status` rules from `style.css`

## Testing
- `black . --check` *(fails: would reformat main.py and tests/test_endpoints.py)*
- `pylint $(git ls-files '*.py') --fail-under=8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d42c348e0833292b733726d44ceb4