### PR TITLE
Fix typing generics for compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import re
 import random
 import asyncio
+from typing import List, Tuple
 
 import aiofiles
 
@@ -47,10 +48,10 @@ def safe_entry_path(entry_date: str) -> Path:
     return path
 
 
-def parse_entry(md_content: str) -> tuple[str, str]:
+def parse_entry(md_content: str) -> Tuple[str, str]:
     """Return (prompt, entry) sections from markdown without raising errors."""
-    prompt_lines: list[str] = []
-    entry_lines: list[str] = []
+    prompt_lines: List[str] = []
+    entry_lines: List[str] = []
     current_section = None
     for line in md_content.splitlines():
         stripped = line.strip()


### PR DESCRIPTION
## Summary
- ensure `pylint` runs on Python 3.8 by avoiding built-in generics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d45347a148332b0ffc895a14c2936