### PR TITLE
Fix generate_prompt handling for missing categories

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -230,13 +230,20 @@ The following issues were identified while reviewing the current code base.
      ```
      【F:main.py†L87-L95】
 
-22. **`generate_prompt` assumes `categories` key exists**
-   - If `prompts.json` lacks the `categories` key, `generate_prompt` raises a `KeyError` when accessing `prompts["categories"].keys()`.
-   - Lines:
+22. **`generate_prompt` assumes `categories` key exists** (fixed)
+   - If `prompts.json` lacked the `categories` key, `generate_prompt` raised a `KeyError` when accessing `prompts["categories"].keys()`.
+   - The function now safely retrieves the dictionary and handles missing or invalid values.
+   - Updated lines:
      ```python
-     categories = list(prompts["categories"].keys())
+     categories_dict = prompts.get("categories")
+     if not isinstance(categories_dict, dict):
+         return {"category": None, "prompt": "No categories found"}
+
+     categories = list(categories_dict.keys())
+     ...
+     candidates = categories_dict.get(category, [])
      ```
-     【F:main.py†L176-L177】
+     【F:main.py†L174-L190】
 
 23. **`safe_entry_path` allows empty filenames**
    - Passing an empty `entry_date` results in the path `/journals/.md` because the sanitized name becomes an empty string.

--- a/main.py
+++ b/main.py
@@ -174,14 +174,19 @@ async def generate_prompt():
     prompts = await load_prompts()
     if not prompts:
         return {"category": None, "prompt": "Prompts file not found"}
-    categories = list(prompts["categories"].keys())
+
+    categories_dict = prompts.get("categories")
+    if not isinstance(categories_dict, dict):
+        return {"category": None, "prompt": "No categories found"}
+
+    categories = list(categories_dict.keys())
 
     if not categories:
         return {"category": None, "prompt": "No categories found"}
 
     category = random.choice(categories)
 
-    candidates = prompts["categories"].get(category, [])
+    candidates = categories_dict.get(category, [])
     if not candidates:
         return {"category": category.capitalize(), "prompt": "No prompts in this category"}
 


### PR DESCRIPTION
## Summary
- handle missing categories gracefully in `generate_prompt`
- document the fix in BUGS.md

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d713b0f6c8332bf27b75f94ecd2c4