### PR TITLE
Fix tests by using temporary directories

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import re
 import random
 import asyncio
 from typing import List, Tuple
+import os
 
 import aiofiles
 
@@ -20,9 +21,12 @@ from fastapi.responses import JSONResponse, HTMLResponse
 
 app = FastAPI()
 
-DATA_DIR = Path("/journals")
-PROMPTS_FILE = Path("/app/prompts.json")
-STATIC_DIR = Path("/app/static")
+# Allow overriding important paths via environment variables for easier testing
+# and deployment in restricted environments.
+APP_DIR = Path(os.getenv("APP_DIR", "/app"))
+DATA_DIR = Path(os.getenv("DATA_DIR", "/journals"))
+PROMPTS_FILE = Path(os.getenv("PROMPTS_FILE", str(APP_DIR / "prompts.json")))
+STATIC_DIR = Path(os.getenv("STATIC_DIR", str(APP_DIR / "static")))
 ENCODING = "utf-8"
 
 # Cache for loaded prompts stored on the FastAPI app state

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -6,7 +6,9 @@
 #
 # pylint: disable=redefined-outer-name
 
+import os
 import shutil
+import tempfile
 from pathlib import Path
 
 import pytest  # pylint: disable=import-error
@@ -14,10 +16,15 @@ from fastapi.testclient import TestClient  # pylint: disable=import-error
 
 # Prepare required directories before importing the app
 ROOT = Path(__file__).resolve().parents[1]
-APP_DIR = Path('/app')
+APP_DIR = Path(tempfile.gettempdir()) / 'ej_app'
 STATIC_DIR = APP_DIR / 'static'
 PROMPTS_FILE = APP_DIR / 'prompts.json'
-DATA_ROOT = Path('/journals')
+DATA_ROOT = Path(tempfile.gettempdir()) / 'ej_journals'
+
+os.environ['APP_DIR'] = str(APP_DIR)
+os.environ['DATA_DIR'] = str(DATA_ROOT)
+os.environ['STATIC_DIR'] = str(STATIC_DIR)
+os.environ['PROMPTS_FILE'] = str(PROMPTS_FILE)
 
 STATIC_DIR.mkdir(parents=True, exist_ok=True)
 DATA_ROOT.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- allow configuring data directories via environment variables
- update tests to use writeable temp dirs before importing the app

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e12aa79308332a35953d047c76aec