### PR TITLE
Fix tests with Python 3.8 by adding Path.is_relative_to

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,17 @@ import asyncio
 from typing import List, Tuple
 import os
 
+# Provide pathlib.Path.is_relative_to on Python < 3.9
+if not hasattr(Path, "is_relative_to"):
+    def _is_relative_to(self: Path, *other: Path) -> bool:
+        try:
+            self.relative_to(*other)
+            return True
+        except ValueError:
+            return False
+
+    Path.is_relative_to = _is_relative_to  # type: ignore[attr-defined]
+
 import aiofiles
 
 from fastapi import FastAPI, Request, HTTPException


### PR DESCRIPTION
## Summary
- provide compatibility implementation for `Path.is_relative_to`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e16f26da88332b7bfa83e0b1154ad