### PR TITLE
Update CI for Python 3.10+

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Minimalist, mobile-first journaling webapp designed for personal use with Docker
 ## Setup instructions
 
 1. **Prepare your environment**
-   Ensure you have Docker and Docker Compose installed.
+    Ensure you have Docker and Docker Compose installed. If you intend to run
+    the application outside of Docker, Python 3.10 or newer is required.
 
 2. **NAS journal storage**
    The NAS location can be configured with the `JOURNALS_DIR` environment


### PR DESCRIPTION
## Summary
- run CI checks on Python 3.10, 3.11 and 3.12
- note Python 3.10+ requirement in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e18b8dec08332997f3439e01c417c