### PR TITLE
Render saved entries as HTML

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import List, Tuple
 
+import markdown
+
 import aiofiles
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -288,11 +290,14 @@ async def view_entry(request: Request, entry_date: str):
     if not prompt or not entry:
         raise HTTPException(status_code=500, detail="Malformed entry file")
 
+    html_entry = markdown.markdown(entry)
+
     return templates.TemplateResponse(
         "echo_journal.html",
         {
             "request": request,
             "content": entry,
+            "content_html": html_entry,
             "date": entry_date,
             "prompt": prompt,
             "readonly": True,  # Read-only mode for archive

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 Jinja2>=3.0
 aiofiles
+markdown
+httpx

--- a/static/style.css
+++ b/static/style.css
@@ -378,3 +378,4 @@ a:visited {
   opacity: 1;
   pointer-events: auto;
 }
+

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -28,14 +28,15 @@
     <button type="button" class="md-btn text-base md:text-2xl" data-action="header" title="Heading">H1</button>
     <button type="button" class="md-btn text-base md:text-2xl" data-action="list" title="List">&#8226;</button>
   </div>
-  {% endif %}
   <label for="journal-text" class="sr-only">Journal entry</label>
   <textarea id="journal-text" class="journal-textarea"
     placeholder="Write freely… describe what happened, how you felt, what you noticed, or anything else that stands out."
-    {% if readonly %}readonly{% endif %}
     oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
     rows="4"
   >{{ content }}</textarea>
+  {% else %}
+  <div class="journal-html w-[90%] max-w-[90%] mx-auto p-6 font-serif text-base leading-relaxed bg-gray-100 dark:bg-slate-700 rounded-xl shadow prose dark:prose-invert">{{ content_html|safe }}</div>
+  {% endif %}
 </section>
     {% if not readonly %}
   <section class="w-full mx-auto mt-6">

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -98,7 +98,7 @@ def test_view_entry_existing(test_client):
     resp = test_client.get('/view/2020-03-03')
     assert resp.status_code == 200
     assert 'B' in resp.text
-    assert 'readonly' in resp.text
+    assert 'journal-html' in resp.text
 
 
 def test_view_entry_multiline_prompt(test_client):


### PR DESCRIPTION
## Summary
- add markdown and httpx as dependencies
- convert journal entries to HTML in `/view/<date>`
- display rendered HTML in template when readonly
- style `.journal-html` block
- update endpoint test expectations
- remove custom CSS for `.journal-html` and rely on Tailwind classes

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e76e55b1483328b0a8e3d16d004ff