### PR TITLE
Fix markdown variable name

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,9 +139,9 @@ async def save_entry(data: dict):
         file_path = safe_entry_path(entry_date)
     except ValueError:
         return {"status": "error", "message": "Invalid date"}
-    markdown = f"# Prompt\n{prompt}\n\n# Entry\n{content}"
+    md_text = f"# Prompt\n{prompt}\n\n# Entry\n{content}"
     async with aiofiles.open(file_path, "w", encoding=ENCODING) as fh:
-        await fh.write(markdown)
+        await fh.write(md_text)
 
     return {"status": "success"}
 


### PR DESCRIPTION
## Summary
- rename local variable `markdown` to `md_text` to avoid shadowing the imported markdown module

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7b60e2d88332a1253eb31c0f1714