### PR TITLE
Refactor templates to rely on tailwind

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3,10 +3,6 @@
 html, body {
   min-height: 100%;
 }
-main {
-  flex: 1;
-}
-
 body {
   background-color: #f5f5f5;
   color: #1f2937;
@@ -15,59 +11,24 @@ body {
   padding: 1rem;
   display: flex;
   flex-direction: column;
+  animation: fadeInBody 1s ease;
 }
-
 @media (prefers-color-scheme: dark) {
   body {
     background-color: #222;
     color: #f5f5f5;
   }
 }
-
-header h1 {
-  font-size: clamp(1.75rem, 2vw + 1rem, 2.5rem);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  margin-bottom: 0.5rem;
+@keyframes fadeInBody {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
-
-.prompt-section {
-  padding: 1rem;
-  border-bottom: 1px solid #4b5563;
-  margin-bottom: 1.5rem;
-}
-
-.prompt-text {
-  font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
-  font-family: 'Merriweather', serif;
-  font-weight: 500;
-  line-height: 1.4;
-  margin-bottom: 0.5rem;
-}
-
-.microcopy {
-  font-size: clamp(0.9rem, 0.8vw + 0.8rem, 1rem);
-  color: #6b7280;
-  margin-top: 0;
-  text-align: center;
-  line-height: 1.4;
-  letter-spacing: 0.02em;
-}
-
-@media (prefers-color-scheme: dark) {
-  .microcopy {
-    color: #9ca3af; /* Tailwind gray-400 */
-  }
-}
-
-
 textarea.journal-textarea {
   display: block;
   width: 90%;
   max-width: 90%;
   margin-left: auto;
   margin-right: auto;
-  height: auto;
   min-height: 6rem;
   padding: 1.5rem;
   border-radius: 1rem;
@@ -77,9 +38,7 @@ textarea.journal-textarea {
   font-family: 'Merriweather', serif;
   font-size: clamp(1rem, 1vw + 0.9rem, 1.25rem);
   line-height: 1.625;
-/*  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05); */
   transition: all 0.3s ease;
-  border-radius: 1rem;
   box-shadow: inset 0 1px 2px rgba(255,255,255,0.05),
               inset 0 -1px 2px rgba(0,0,0,0.1),
               0 4px 12px rgba(0,0,0,0.2);
@@ -89,242 +48,45 @@ textarea.journal-textarea {
   );
   background-repeat: repeat;
   background-size: 512px 512px;
-  background-blend-mode: multiply; /* for light mode */
+  background-blend-mode: multiply;
 }
-
-/* Dark mode adjustment */
 @media (prefers-color-scheme: dark) {
   textarea.journal-textarea {
-    background-color: #666666;
-    background-blend-mode: multiply; /* change from screen to multiply */
+    background-color: #374151;
+    color: #f5f5f5;
+    border-color: #4b5563;
+    background-blend-mode: multiply;
+    box-shadow:
+      inset 0 1px 2px rgba(255, 255, 255, 0.08),
+      0 1px 6px rgba(255, 255, 255, 0.12);
   }
 }
-
 textarea.journal-textarea::placeholder {
   color: #9ca3af;
 }
-
 textarea.journal-textarea:focus {
   outline: none;
   border-color: #64748b;
   box-shadow: 0 0 0 2px #64748b;
 }
 
-@media (prefers-color-scheme: dark) {
-  textarea.journal-textarea {
-    background-image: image-set(
-      url('/static/textures/paper-texture.avif') type('image/avif'),
-      url('/static/textures/paper-texture.webp') type('image/webp')
-    );
-    background-repeat: repeat;
-    background-size: 512px 512px;
-    color: #f5f5f5;
-    border-color: #4b5563;
-    background-color: #374151; /* dark slate tone */
-    background-blend-mode: multiply;
-  }
-}
-
-button.save-button {
-  display: block;
-  width: 65%;
-  max-width: 15rem;
-  margin: 0.75rem auto 0 auto;
-  background-color: #64748b;
-  color: #ffffff;
-  border-radius: 1rem;
-  padding: 0.75rem;
-  font-size: 1.125rem;
-  font-weight: 600;
-  font-family: 'Nunito', sans-serif;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-  transition: background-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-button.save-button:hover {
-  background-color: #475569;
-  filter: brightness(1.05);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
-}
-
-@media (prefers-color-scheme: dark) {
-  button.save-button {
-    background-color: #7b8794;
-  }
-  button.save-button:hover {
-    background-color: #64748b;
-  }
-}
-
-
-.footer-text {
-  font-size: clamp(0.9rem, 0.8vw + 0.8rem, 1rem); /* match improved microcopy sizing */
-  color: #6b7280;
-  text-align: center;
-  margin-top: 2rem;
-  line-height: 1.4;
-  letter-spacing: 0.02em;
-/*  opacity: 0.6; */
-}
-
-@media (prefers-color-scheme: dark) {
-  .footer-text {
-    color: #9ca3af; /* Tailwind gray-400 */
-  }
-}
-
-
-.welcome-message {
-  opacity: 0;
-  transition: opacity 2s ease 0.3s;
-  font-family: 'Merriweather', serif;
-  font-weight: 700;
-  font-size: clamp(1.75rem, 2vw + 1rem, 2.5rem);
-  text-align: center;
-  margin-bottom: 0.5rem;
-  transition: opacity 2s ease 0.3s;
-}
-
-body {
-  animation: fadeInBody 1s ease;
-}
-
-@keyframes fadeInBody {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-/* Subtle inline logo styling */
-.logo-inline {
-  height: 4rem;
-  vertical-align: middle;
-  opacity: 0.5;
-/*  filter: brightness(0) invert(0); /* Normal appearance in light mode */
-  transition: filter 0.3s ease, opacity 0.3s ease;
-}
-
-
-@media (prefers-color-scheme: dark) {
-  textarea.journal-textarea {
-    box-shadow:
-      inset 0 1px 2px rgba(255, 255, 255, 0.08),
-      0 1px 6px rgba(255, 255, 255, 0.12);
-  }
-
-  button.save-button {
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
-  }
-
-  button.save-button:hover {
-    box-shadow: 0 2px 6px rgba(255, 255, 255, 0.2);
-
-  }
-}
-
-/* Make visited links consistent and visible in dark mode */
-a:visited {
-  color: #60a5fa; /* Tailwind's blue-400 */
-}
-
-/* Generic muted text color for secondary microcopy */
-.text-muted {
-  color: #6b7280; /* gray-500 for light mode */
-}
-
-@media (prefers-color-scheme: dark) {
-  .text-muted {
-    color: #9ca3af; /* gray-400 for dark mode */
-  }
-}
-
-/* Divider color for list separators and left border */
-.border-divider {
-  border-color: #d1d5db; /* gray-300 for light mode */
-}
-
-@media (prefers-color-scheme: dark) {
-  .border-divider {
-    border-color: #4b5563; /* gray-600 for dark mode */
-  }
-}
-
-/* Link styling harmonized for both modes */
-.link-style {
-  color: #2563eb; /* blue-600 for light mode (vivid, readable) */
-  text-decoration: none;
-}
-
-.link-style:hover {
-  text-decoration: underline;
-}
-
-.active-link {
-  font-weight: 600;
-}
-
-.sticky-header {
-  position: sticky;
-  top: 0;
-  background-color: inherit;
-  z-index: 10;
-}
-
-@media (prefers-color-scheme: dark) {
-  .link-style {
-    color: #60a5fa; /* blue-400 for dark mode (brighter, readable) */
-  }
-}
-
-/* Screen reader only helper */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-/* Keyboard focus outline */
-:focus {
-  outline: 2px solid #2563eb;
-  outline-offset: 2px;
-}
-
-/* Error text */
-.error-text {
-  color: #dc2626; /* red-600 */
-}
-
-/* Minimal markdown toolbar */
 .markdown-toolbar {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
-
-.markdown-toolbar .md-btn:hover {
-  background-color: #d1d5db; /* gray-300 */
+.editor-container:hover .markdown-toolbar,
+.editor-container:focus-within .markdown-toolbar {
+  opacity: 1;
+  pointer-events: auto;
 }
-
-@media (prefers-color-scheme: dark) {
-  .markdown-toolbar .md-btn {
-    background-color: #4b5563; /* gray-600 */
-    border-color: #6b7280; /* gray-500 */
-    color: #f5f5f5;
-  }
-  .markdown-toolbar .md-btn:hover {
-    background-color: #6b7280; /* gray-500 */
-  }
-}
-
 .editor-container {
-  background-color: var(--editor-bg); /* Match dark mode theme */
+  background-color: var(--editor-bg);
   border-radius: 0.75rem;
   padding: 0.75rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
@@ -332,50 +94,27 @@ a:visited {
   flex-direction: column;
   gap: 0.5rem;
 }
-
-
-.prompt-section + .editor-container {
-  margin-top: 0.5rem;
-}
-
-.editor-container:hover .markdown-toolbar,
-.editor-container:focus-within .markdown-toolbar {
-  opacity: 1;
-}
-
-
 .md-btn {
   background: none;
   border: none;
   color: var(--editor-toolbar-color, #ccc);
   cursor: pointer;
-  padding: 0.4rem  0.6rem;
+  padding: 0.4rem 0.6rem;
 }
-
 .md-btn:hover {
   color: var(--accent-color, #fff);
 }
-
-.journal-textarea {
-  background: transparent;
-  border: none;
-  resize: vertical;
-  width: 100%;
-  color: inherit;
-  font-size: 1rem;
-  line-height: 1.5;
-  min-height: 10rem;
+@media (prefers-color-scheme: dark) {
+  .markdown-toolbar .md-btn {
+    background-color: #4b5563;
+    border-color: #6b7280;
+    color: #f5f5f5;
+  }
+  .markdown-toolbar .md-btn:hover {
+    background-color: #6b7280;
+  }
 }
 
-.markdown-toolbar {
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
+.error-text {
+  color: #dc2626;
 }
-
-.editor-container:hover .markdown-toolbar,
-.editor-container:focus-within .markdown-toolbar {
-  opacity: 1;
-  pointer-events: auto;
-}
-

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -3,22 +3,22 @@
 {% block title %}Echo Journal Archives{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="welcome-message">Archive</h1>
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 transition-opacity duration-[2000ms] delay-300">Archive</h1>
 {% endblock %}
 
 {% block content %}
 
-<p class="text-sm text-muted mt-1 mb-4 text-center">
+<p class="text-sm mt-1 mb-4 text-center text-gray-500 dark:text-gray-400">
   A gentle record of your days — grouped for easy reflection.
 </p>
 
 <div class="w-full mx-auto">
   {% for period, period_entries in entries.items() %}
     <h2 class="text-lg font-medium mt-4">{{ period }}</h2>
-    <ul class="pl-4 border-l border-divider space-y-1">
+    <ul class="pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1">
       {% for entry_date, content in period_entries %}
-        <li class="py-1 border-b border-divider">
-          <a href="/view/{{ entry_date }}" class="text-sm link-style">{{ entry_date }}</a>
+        <li class="py-1 border-b border-gray-300 dark:border-gray-600">
+          <a href="/view/{{ entry_date }}" class="text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline">{{ entry_date }}</a>
           — {{ content[:75] }}...
         </li>
       {% endfor %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,15 +13,15 @@
   <meta name="theme-color" content="#1a1a1a">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-6">
-  <header class="flex justify-between items-center w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto mb-4 sticky-header">
+<body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
+  <header class="flex justify-between items-center w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto mb-4 sticky top-0 bg-inherit z-10">
     {% block header_title %}
     <h1 class="welcome-message">Echo Journal</h1>
     {% endblock %}
     <nav class="space-x-4 text-sm" aria-label="Main navigation">
-      <a href="/" class="link-style {% if active_page == 'home' %}active-link{% endif %}">Home</a>
-      <a href="/archive" class="link-style {% if active_page == 'archive' %}active-link{% endif %}">Archive</a>
-      <a href="/settings" class="link-style {% if active_page == 'settings' %}active-link{% endif %}">Settings</a>
+      <a href="/" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'home' %}font-semibold{% endif %}">Home</a>
+      <a href="/archive" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'archive' %}font-semibold{% endif %}">Archive</a>
+      <a href="/settings" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'settings' %}font-semibold{% endif %}">Settings</a>
     </nav>
   </header>
 

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -3,7 +3,7 @@
 {% block title %}Echo Journal{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="welcome-message"
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 transition-opacity duration-[2000ms] delay-300"
       {% if not readonly %} data-dynamic-greeting="true"{% endif %}>
     {% if readonly %}
       Welcome back to {{ date }}
@@ -15,9 +15,9 @@
 
 {% block content %}
 <section class="w-full mx-auto space-y-2 text-center">
-  <div class="prompt-section">
-    <p class="prompt-text">{{ prompt }}</p>
-    <p class="microcopy">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
+  <div class="p-4 border-b border-gray-600 mb-6">
+    <p class="font-serif font-medium text-[clamp(1.5rem,2vw+1rem,2rem)] leading-snug mb-2">{{ prompt }}</p>
+    <p class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
   </div>
 </section>
 <section class="w-full mx-auto editor-container">
@@ -40,12 +40,12 @@
 </section>
     {% if not readonly %}
   <section class="w-full mx-auto mt-6">
-    <button id="save-button" class="save-button" aria-label="Save entry">Save Entry</button>
+    <button id="save-button" class="block w-[65%] max-w-[15rem] mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>
     {% endif %}
 
-  <footer class="w-full mx-auto mt-8 footer-text" id="save-status" aria-live="polite" role="status">
-  <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="logo-inline">
+  <footer class="w-full mx-auto mt-8 text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide" id="save-status" aria-live="polite" role="status">
+  <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   {% if content %}Last saved: loaded from file{% else %}Last saved: no entry yet{% endif %} — Echo Journal
   </footer>
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,12 +3,12 @@
 {% block title %}Settings - Echo Journal{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="welcome-message">Settings</h1>
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 transition-opacity duration-[2000ms] delay-300">Settings</h1>
 {% endblock %}
 
 {% block content %}
 
-<p class="text-sm text-muted text-center mb-4">
+<p class="text-sm text-center mb-4 text-gray-500 dark:text-gray-400">
   Adjust your preferences below. Changes are saved locally in your browser.
 </p>
 
@@ -19,8 +19,8 @@
   </label>
 </form>
 
-<footer class="w-full max-w-md mt-8 footer-text">
-  <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="logo-inline">
+<footer class="w-full max-w-md mt-8 text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
+  <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   Echo Journal
 </footer>
 


### PR DESCRIPTION
## Summary
- reduce custom CSS and keep only special rules
- use Tailwind classes directly in templates

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7c79fc388332a9d5c84f355b6c7a