### PR TITLE
Fix paragraphs spacing in archived journals

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -127,3 +127,5 @@ textarea.journal-textarea:focus {
 .error-text {
   color: #dc2626;
 }
+
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/echo_journal_transparent_16x16.png">
   <link rel="icon" type="image/x-icon" href="/static/icons/echo_journal_favicon.ico">
   <meta name="theme-color" content="#1a1a1a">
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
   <header class="flex justify-between items-center w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto mb-4 sticky top-0 bg-inherit z-10">

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -35,7 +35,7 @@
     rows="4"
   >{{ content }}</textarea>
   {% else %}
-    <div class="journal-html w-[90%] max-w-[90%] mx-auto p-6 font-serif text-lg sm:text-xl md:text-2xl leading-relaxed bg-gray-100 dark:bg-slate-700 rounded-xl shadow">
+    <div class="journal-html w-[90%] max-w-[90%] mx-auto p-6 font-serif bg-gray-100 dark:bg-slate-700 rounded-xl shadow prose dark:prose-invert prose-lg">
     {{ content_html|safe }}</div>
   {% endif %}
 </section>


### PR DESCRIPTION
## Summary
- style archived entry paragraphs with Tailwind typography
- use Tailwind CDN typography plugin

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eadd92060833291086770ad4bf241