### PR TITLE
Improve dark mode toggle

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -22,11 +22,9 @@ body {
   flex-direction: column;
   animation: fadeInBody 1s ease;
 }
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: #222;
-    color: #f5f5f5;
-  }
+.dark body {
+  background-color: #222;
+  color: #f5f5f5;
 }
 @keyframes fadeInBody {
   from { opacity: 0; }
@@ -59,16 +57,14 @@ textarea.journal-textarea {
   background-size: 512px 512px;
   background-blend-mode: multiply;
 }
-@media (prefers-color-scheme: dark) {
-  textarea.journal-textarea {
-    background-color: #374151;
-    color: #f5f5f5;
-    border-color: #4b5563;
-    background-blend-mode: multiply;
-    box-shadow:
-      inset 0 1px 2px rgba(255, 255, 255, 0.08),
-      0 1px 6px rgba(255, 255, 255, 0.12);
-  }
+.dark textarea.journal-textarea {
+  background-color: #374151;
+  color: #f5f5f5;
+  border-color: #4b5563;
+  background-blend-mode: multiply;
+  box-shadow:
+    inset 0 1px 2px rgba(255, 255, 255, 0.08),
+    0 1px 6px rgba(255, 255, 255, 0.12);
 }
 textarea.journal-textarea::placeholder {
   color: #9ca3af;
@@ -113,15 +109,13 @@ textarea.journal-textarea:focus {
 .md-btn:hover {
   color: var(--accent-color, #fff);
 }
-@media (prefers-color-scheme: dark) {
-  .markdown-toolbar .md-btn {
-    background-color: #4b5563;
-    border-color: #6b7280;
-    color: #f5f5f5;
-  }
-  .markdown-toolbar .md-btn:hover {
-    background-color: #6b7280;
-  }
+.dark .markdown-toolbar .md-btn {
+  background-color: #4b5563;
+  border-color: #6b7280;
+  color: #f5f5f5;
+}
+.dark .markdown-toolbar .md-btn:hover {
+  background-color: #6b7280;
 }
 
 .error-text {

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Echo Journal{% endblock %}</title>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600&family=Merriweather:wght@400;700&display=swap" rel="stylesheet">
+  <script>
+    /* Ensure Tailwind uses class-based dark mode and apply saved preference */
+    tailwind = { config: { darkMode: 'class' } };
+    (function () {
+      const pref = localStorage.getItem('dark-mode');
+      if (pref === 'true') {
+        document.documentElement.classList.add('dark');
+      } else if (pref === 'false') {
+        document.documentElement.classList.remove('dark');
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="/static/style.css">
   <!-- Favicon integration -->
   <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/echo_journal_transparent_32x32.png">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -35,9 +35,9 @@ document.addEventListener("DOMContentLoaded", () => {
   const toggle = document.getElementById('dark-toggle');
   if (toggle) {
     const stored = localStorage.getItem('dark-mode');
-    if (stored === 'true') {
+    if (stored === 'true' ||
+        (stored === null && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
       toggle.checked = true;
-      document.documentElement.classList.add('dark');
     }
     toggle.addEventListener('change', () => {
       if (toggle.checked) {


### PR DESCRIPTION
## Summary
- set Tailwind dark mode to use the `class` strategy and apply saved preference
- update style rules to use `.dark` selectors instead of `prefers-color-scheme`
- adjust settings page toggle logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebc2fe158833298ee42a93dfa8048