### PR TITLE
Add letter fade-in script for welcome message

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -3,7 +3,7 @@
 {% block title %}Echo Journal{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 transition-opacity duration-[2000ms] delay-300"
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 whitespace-nowrap"
       {% if not readonly %} data-dynamic-greeting="true"{% endif %}>
     {% if readonly %}
       Welcome back to {{ date }}
@@ -70,8 +70,20 @@ document.addEventListener("DOMContentLoaded", () => {
       el.textContent = greeting;
     }
 
+    const text = el.textContent.trim();
+    el.textContent = "";
+    const frag = document.createDocumentFragment();
+    [...text].forEach((char, idx) => {
+      const span = document.createElement('span');
+      span.textContent = char;
+      span.className = 'inline-block opacity-0 transition-opacity duration-300';
+      span.style.transitionDelay = `${idx * 60}ms`;
+      frag.appendChild(span);
+    });
+    el.appendChild(frag);
+
     requestAnimationFrame(() => {
-      el.style.opacity = 1;
+      el.querySelectorAll('span').forEach(span => span.classList.add('opacity-100'));
     });
   }
 


### PR DESCRIPTION
## Summary
- wrap `#welcome-message` text in spans on page load
- stagger each span's opacity transition for a smooth reveal

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec3fd495083329acfd3b60fc65c58