### PR TITLE
Implement global dark mode toggle

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,11 +36,35 @@
       <a href="/" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'home' %}font-semibold{% endif %}">Home</a>
       <a href="/archive" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'archive' %}font-semibold{% endif %}">Archive</a>
       <a href="/settings" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'settings' %}font-semibold{% endif %}">Settings</a>
+      <button id="nav-dark-toggle" aria-label="Toggle dark mode" class="ml-2 text-xl align-middle">🌙</button>
     </nav>
   </header>
 
   <main class="w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto space-y-6">
     {% block content %}{% endblock %}
   </main>
+  <script>
+  (function() {
+    const btn = document.getElementById('nav-dark-toggle');
+    if (!btn) return;
+    const updateIcon = (isDark) => { btn.textContent = isDark ? '🌞' : '🌙'; };
+    const setDarkMode = (isDark) => {
+      if (isDark) {
+        document.documentElement.classList.add('dark');
+        localStorage.setItem('dark-mode', 'true');
+      } else {
+        document.documentElement.classList.remove('dark');
+        localStorage.setItem('dark-mode', 'false');
+      }
+      updateIcon(isDark);
+    };
+    updateIcon(document.documentElement.classList.contains('dark'));
+    btn.addEventListener('click', () => {
+      const isDark = !document.documentElement.classList.contains('dark');
+      setDarkMode(isDark);
+    });
+    window.setDarkMode = setDarkMode;
+  })();
+  </script>
 </body>
 </html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -40,12 +40,16 @@ document.addEventListener("DOMContentLoaded", () => {
       toggle.checked = true;
     }
     toggle.addEventListener('change', () => {
-      if (toggle.checked) {
-        document.documentElement.classList.add('dark');
-        localStorage.setItem('dark-mode', 'true');
+      if (typeof window.setDarkMode === 'function') {
+        window.setDarkMode(toggle.checked);
       } else {
-        document.documentElement.classList.remove('dark');
-        localStorage.setItem('dark-mode', 'false');
+        if (toggle.checked) {
+          document.documentElement.classList.add('dark');
+          localStorage.setItem('dark-mode', 'true');
+        } else {
+          document.documentElement.classList.remove('dark');
+          localStorage.setItem('dark-mode', 'false');
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- add a dark mode button to the site header
- expose a global `setDarkMode` helper so pages can sync the state
- use `setDarkMode` in the settings page toggle

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec8e294d48332872d8e7b1a93eb51