### PR TITLE
Enhance dark mode handling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -81,6 +81,7 @@ textarea.journal-textarea:focus {
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  background-color: #f0f0f0;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
@@ -90,14 +91,20 @@ textarea.journal-textarea:focus {
   opacity: 1;
   pointer-events: auto;
 }
+.dark .markdown-toolbar {
+  background-color: #4b5563;
+}
 .editor-container {
-  background-color: var(--editor-bg);
+  background-color: #fff;
   border-radius: 0.75rem;
   padding: 0.75rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+.dark .editor-container {
+  background-color: #374151;
 }
 .md-btn {
   background: none;

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,14 +9,30 @@
     /* Ensure Tailwind uses class-based dark mode and apply saved preference */
     tailwind = { config: { darkMode: 'class' } };
     (function () {
-      const pref = localStorage.getItem('dark-mode');
+      const applySystemPreference = () => {
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (prefersDark) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+        return prefersDark;
+      };
+      let pref = localStorage.getItem('dark-mode');
       if (pref === 'true') {
         document.documentElement.classList.add('dark');
-      } else if (pref === 'false') {
-        document.documentElement.classList.remove('dark');
-      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark');
+      } else {
+        localStorage.removeItem('dark-mode');
+        pref = null;
+        applySystemPreference();
       }
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        if (!localStorage.getItem('dark-mode')) {
+          if (e.matches) document.documentElement.classList.add('dark');
+          else document.documentElement.classList.remove('dark');
+          updateIcon(e.matches);
+        }
+      });
     })();
   </script>
   <link rel="stylesheet" href="/static/style.css">
@@ -52,16 +68,19 @@
       if (isDark) {
         document.documentElement.classList.add('dark');
         localStorage.setItem('dark-mode', 'true');
+        updateIcon(true);
       } else {
-        document.documentElement.classList.remove('dark');
-        localStorage.setItem('dark-mode', 'false');
+        localStorage.removeItem('dark-mode');
+        const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (prefers) document.documentElement.classList.add('dark');
+        else document.documentElement.classList.remove('dark');
+        updateIcon(prefers);
       }
-      updateIcon(isDark);
     };
     updateIcon(document.documentElement.classList.contains('dark'));
     btn.addEventListener('click', () => {
-      const isDark = !document.documentElement.classList.contains('dark');
-      setDarkMode(isDark);
+      const hasPref = localStorage.getItem('dark-mode') === 'true';
+      setDarkMode(!hasPref);
     });
     window.setDarkMode = setDarkMode;
   })();

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -47,8 +47,12 @@ document.addEventListener("DOMContentLoaded", () => {
           document.documentElement.classList.add('dark');
           localStorage.setItem('dark-mode', 'true');
         } else {
-          document.documentElement.classList.remove('dark');
-          localStorage.setItem('dark-mode', 'false');
+          localStorage.removeItem('dark-mode');
+          if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.classList.add('dark');
+          } else {
+            document.documentElement.classList.remove('dark');
+          }
         }
       }
     });


### PR DESCRIPTION
## Summary
- update dark mode script to fall back to system preference
- style toolbar and editor container for dark mode
- allow disabling dark mode to clear stored preference

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ed1c2e40483329bd0817ae6d5a286