### PR TITLE
Fix dark mode toggle

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,24 +13,33 @@
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         if (prefersDark) {
           document.documentElement.classList.add('dark');
+          document.body.classList.add('dark');
         } else {
           document.documentElement.classList.remove('dark');
+          document.body.classList.remove('dark');
         }
         return prefersDark;
       };
       let pref = localStorage.getItem('dark-mode');
       if (pref === 'true') {
         document.documentElement.classList.add('dark');
+        document.body.classList.add('dark');
       } else if (pref === 'false') {
         document.documentElement.classList.remove('dark');
+        document.body.classList.remove('dark');
       } else {
         pref = null;
         applySystemPreference();
       }
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
           if (!localStorage.getItem('dark-mode')) {
-            if (e.matches) document.documentElement.classList.add('dark');
-            else document.documentElement.classList.remove('dark');
+            if (e.matches) {
+              document.documentElement.classList.add('dark');
+              document.body.classList.add('dark');
+            } else {
+              document.documentElement.classList.remove('dark');
+              document.body.classList.remove('dark');
+            }
             if (typeof window.updateIcon === 'function') {
               window.updateIcon(e.matches);
             }
@@ -69,12 +78,14 @@
     const updateIcon = (isDark) => { btn.textContent = isDark ? '🌞' : '🌙'; };
     const setDarkMode = (isDark) => {
       document.documentElement.classList.toggle('dark', isDark);
+      document.body.classList.toggle('dark', isDark);
       localStorage.setItem('dark-mode', isDark ? 'true' : 'false');
       updateIcon(isDark);
     };
     window.updateIcon = updateIcon;
     window.setDarkMode = setDarkMode;
     const initialDark = document.documentElement.classList.contains('dark');
+    if (initialDark) document.body.classList.add('dark');
     updateIcon(initialDark);
     btn.addEventListener('click', () => {
       const currentlyDark = document.documentElement.classList.contains('dark');

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -8,6 +8,7 @@
 
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
@@ -26,11 +27,15 @@ os.environ["DATA_DIR"] = str(DATA_ROOT)
 os.environ["STATIC_DIR"] = str(STATIC_DIR)
 os.environ["PROMPTS_FILE"] = str(PROMPTS_FILE)
 
+# Ensure directories for the application exist before importing ``main``
 STATIC_DIR.mkdir(parents=True, exist_ok=True)
 DATA_ROOT.mkdir(parents=True, exist_ok=True)
 # copy prompts file if not already
 if not PROMPTS_FILE.exists():
     shutil.copy(ROOT / "prompts.json", PROMPTS_FILE)
+
+# Make sure the repository root is on ``sys.path`` so ``main`` can be imported
+sys.path.insert(0, str(ROOT))
 
 # Import the application after environment setup
 import main  # type: ignore  # pylint: disable=wrong-import-position


### PR DESCRIPTION
## Summary
- update dark mode scripts to toggle class on `<body>` as well as `<html>`
- ensure tests can import the application by adding repo root to `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed83983e48332821032b026dbebc3