### PR TITLE
Hide markdown toolbar until text area focus

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -86,9 +86,8 @@ textarea.journal-textarea:focus {
   background-color: #f0f0f0;
   width: max-content;
 }
-.editor-container:hover .markdown-toolbar,
 .editor-container:focus-within .markdown-toolbar {
-  display: flex;
+    display: flex;
 }
 .dark .markdown-toolbar {
   background-color: #4b5563;

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -22,7 +22,7 @@
 </section>
 <section class="w-full mx-auto editor-container">
   {% if not readonly %}
-  <div id="md-toolbar" class="flex space-x-2 justify-center markdown-toolbar" aria-label="Formatting toolbar">
+  <div id="md-toolbar" class="space-x-2 justify-center markdown-toolbar" aria-label="Formatting toolbar">
     <button type="button" class="md-btn text-base md:text-2xl" data-action="bold" title="Bold"><strong>B</strong></button>
     <button type="button" class="md-btn text-base md:text-2xl" data-action="italic" title="Italic"><em>I</em></button>
     <button type="button" class="md-btn text-base md:text-2xl" data-action="header" title="Heading">H1</button>


### PR DESCRIPTION
## Summary
- keep markdown toolbar hidden by default
- only reveal toolbar when the editor section has focus
- remove flex utility so Tailwind doesn't override toolbar display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f59792bf08332aafc60cdaceb65f6