### PR TITLE
Improve dark mode support

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -127,5 +127,8 @@ textarea.journal-textarea:focus {
 .error-text {
   color: #dc2626;
 }
+.dark .error-text {
+  color: #f87171;
+}
 
 

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -18,8 +18,8 @@
     <ul class="pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1">
       {% for entry_date, content in period_entries %}
         <li class="py-1 border-b border-gray-300 dark:border-gray-600">
-          <a href="/view/{{ entry_date }}" class="text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline">{{ entry_date }}</a>
-          — {{ content[:75] }}...
+          <a href="/view/{{ entry_date }}" class="text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
+        — {{ content[:75] }}...
         </li>
       {% endfor %}
     </ul>

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,14 +61,14 @@
     <h1 class="welcome-message">Echo Journal</h1>
     {% endblock %}
     <nav class="space-x-4 text-sm" aria-label="Main navigation">
-      <a href="/" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'home' %}font-semibold{% endif %}">Home</a>
-      <a href="/archive" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'archive' %}font-semibold{% endif %}">Archive</a>
-      <a href="/settings" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 hover:underline {% if active_page == 'settings' %}font-semibold{% endif %}">Settings</a>
+      <a href="/" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'home' %}font-semibold{% endif %}">Home</a>
+      <a href="/archive" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'archive' %}font-semibold{% endif %}">Archive</a>
+      <a href="/settings" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'settings' %}font-semibold{% endif %}">Settings</a>
       <button id="nav-dark-toggle" aria-label="Toggle dark mode" class="ml-2 text-xl align-middle">🌙</button>
     </nav>
   </header>
 
-  <main class="w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto space-y-6">
+  <main class="prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto space-y-6">
     {% block content %}{% endblock %}
   </main>
   <script>


### PR DESCRIPTION
## Summary
- expand dark mode coverage
- update visited link styling for dark mode
- enhance error text readability in dark mode
- unify page typography with `prose`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5b232b848332a0fc004ba5c55afd