### PR TITLE
Ensure dark mode covers all containers

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -15,9 +15,9 @@
 <div class="w-full mx-auto">
   {% for period, period_entries in entries.items() %}
     <h2 class="text-lg font-medium mt-4">{{ period }}</h2>
-    <ul class="pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1">
+    <ul class="pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1 text-gray-800 dark:text-gray-100">
       {% for entry_date, content in period_entries %}
-        <li class="py-1 border-b border-gray-300 dark:border-gray-600">
+        <li class="py-1 border-b border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100">
           <a href="/view/{{ entry_date }}" class="text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
         — {{ content[:75] }}...
         </li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,7 +56,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
-  <header class="flex justify-between items-center w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto mb-4 sticky top-0 bg-inherit z-10">
+  <header class="flex justify-between items-center w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto mb-4 sticky top-0 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100 z-10">
     {% block header_title %}
     <h1 class="welcome-message">Echo Journal</h1>
     {% endblock %}
@@ -68,7 +68,7 @@
     </nav>
   </header>
 
-  <main class="prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto space-y-6">
+  <main class="prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
     {% block content %}{% endblock %}
   </main>
   <script>

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -14,13 +14,13 @@
 {% endblock %}
 
 {% block content %}
-<section class="w-full mx-auto space-y-2 text-center">
+<section class="w-full mx-auto space-y-2 text-center bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
   <div class="p-4 border-b border-gray-300 dark:border-gray-600 mb-6">
     <p class="font-sans font-medium text-[clamp(1.5rem,2vw+1rem,2rem)] leading-snug mb-2">{{ prompt }}</p>
     <p class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
   </div>
 </section>
-<section class="w-full mx-auto editor-container">
+<section class="w-full mx-auto editor-container bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
   {% if not readonly %}
   <div id="md-toolbar" class="space-x-2 justify-center markdown-toolbar" aria-label="Formatting toolbar">
     <button type="button" class="md-btn text-base md:text-2xl" data-action="bold" title="Bold"><strong>B</strong></button>
@@ -40,12 +40,12 @@
   {% endif %}
 </section>
     {% if not readonly %}
-  <section class="w-full mx-auto mt-6">
+  <section class="w-full mx-auto mt-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
     <button id="save-button" class="block w-[65%] max-w-[15rem] mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>
     {% endif %}
 
-  <footer class="w-full mx-auto mt-8 text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide" id="save-status" aria-live="polite" role="status">
+  <footer class="w-full mx-auto mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide" id="save-status" aria-live="polite" role="status">
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   {% if content %}Last saved: loaded from file{% else %}Last saved: no entry yet{% endif %} — Echo Journal
   </footer>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,7 +19,7 @@
   </label>
 </form>
 
-<footer class="w-full max-w-md mt-8 text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
+<footer class="w-full max-w-md mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   Echo Journal
 </footer>


### PR DESCRIPTION
## Summary
- add explicit dark and light colors to `header` and `main`
- include dark mode classes on archive list items
- ensure all sections and footers specify dark variants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5f3589748332acdd6cdc1fb6d8b2