### PR TITLE
Add Tailwind config for class-based dark mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './templates/**/*.html',
+    './main.py',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('@tailwindcss/typography')],
+};


### PR DESCRIPTION
## Summary
- add a basic `tailwind.config.js` enabling class-based dark mode

## Checklist
- [x] Tests pass (`pytest`)
- [x] Code is formatted with `black` and linted with `pylint`
- [ ] Documentation updated if needed

------
https://chatgpt.com/codex/tasks/task_e_687f6186de108332a1d8d6a601d5a05b