### PR TITLE
Remove dark mode toggle

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -285,37 +285,3 @@ The following issues were identified while reviewing the current code base.
      ```
      【F:templates/echo_journal.html†L24-L32】
 
-26. **Dark mode toggle has no effect when system already uses dark mode** (fixed)
-   - The CSS applies dark colors automatically with the `prefers-color-scheme` media query.
-   - The toggle in `settings.html` only toggles a `dark` class, which does not override these rules.
-   - Lines:
-     ```css
-     @media (prefers-color-scheme: dark) {
-       body {
-         background-color: #222;
-         color: #f5f5f5;
-       }
-     }
-     ```
-     【F:static/style.css†L20-L25】
-   - Toggle script lines:
-     ```javascript
-     const toggle = document.getElementById('dark-toggle');
-     if (toggle) {
-       const stored = localStorage.getItem('dark-mode');
-       if (stored === 'true') {
-         toggle.checked = true;
-         document.documentElement.classList.add('dark');
-       }
-       toggle.addEventListener('change', () => {
-         if (toggle.checked) {
-           document.documentElement.classList.add('dark');
-           localStorage.setItem('dark-mode', 'true');
-         } else {
-           document.documentElement.classList.remove('dark');
-           localStorage.setItem('dark-mode', 'false');
-         }
-       });
-     }
-     ```
-     【F:templates/settings.html†L28-L52】

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minimalist, mobile-first journaling webapp designed for personal use with Docker
 - No authentication, intended for secure local network (LAN) usage
 - Backend implemented with FastAPI and Jinja2 templates
 - Archive view to browse past entries
-- Settings page with client-side dark mode toggle
+- Settings page placeholder for future options
 
 ## Project structure
 ```

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,46 +6,17 @@
   <title>{% block title %}Echo Journal{% endblock %}</title>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600&family=Merriweather:wght@400;700&display=swap" rel="stylesheet">
   <script>
-    /* Ensure Tailwind uses class-based dark mode and apply saved preference */
-    tailwind = { config: { darkMode: 'class' } };
-    (function () {
-      const applySystemPreference = () => {
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (prefersDark) {
-          document.documentElement.classList.add('dark');
-          if (document.body) document.body.classList.add('dark');
-        } else {
-          document.documentElement.classList.remove('dark');
-          if (document.body) document.body.classList.remove('dark');
-        }
-        return prefersDark;
-      };
-      let pref = localStorage.getItem('dark-mode');
-      if (pref === 'true') {
-        document.documentElement.classList.add('dark');
-        if (document.body) document.body.classList.add('dark');
-      } else if (pref === 'false') {
-        document.documentElement.classList.remove('dark');
-        if (document.body) document.body.classList.remove('dark');
-      } else {
-        pref = null;
-        applySystemPreference();
-      }
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-          if (!localStorage.getItem('dark-mode')) {
-            if (e.matches) {
-              document.documentElement.classList.add('dark');
-              if (document.body) document.body.classList.add('dark');
-            } else {
-              document.documentElement.classList.remove('dark');
-              if (document.body) document.body.classList.remove('dark');
-            }
-            if (typeof window.updateIcon === 'function') {
-              window.updateIcon(e.matches);
-            }
-          }
-        });
-    })();
+      /* Ensure Tailwind uses class-based dark mode and follow system preference */
+      tailwind = { config: { darkMode: 'class' } };
+      (function () {
+        const applyPreference = () => {
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          document.documentElement.classList.toggle('dark', prefersDark);
+          if (document.body) document.body.classList.toggle('dark', prefersDark);
+        };
+        applyPreference();
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', applyPreference);
+      })();
   </script>
   <link rel="stylesheet" href="/static/style.css">
   <!-- Favicon integration -->
@@ -64,34 +35,11 @@
       <a href="/" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'home' %}font-semibold{% endif %}">Home</a>
       <a href="/archive" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'archive' %}font-semibold{% endif %}">Archive</a>
       <a href="/settings" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'settings' %}font-semibold{% endif %}">Settings</a>
-      <button id="nav-dark-toggle" aria-label="Toggle dark mode" class="ml-2 text-xl align-middle">🌙</button>
     </nav>
   </header>
 
   <main class="prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
     {% block content %}{% endblock %}
   </main>
-  <script>
-  (function() {
-    const btn = document.getElementById('nav-dark-toggle');
-    if (!btn) return;
-    const updateIcon = (isDark) => { btn.textContent = isDark ? '🌞' : '🌙'; };
-    const setDarkMode = (isDark) => {
-      document.documentElement.classList.toggle('dark', isDark);
-      document.body.classList.toggle('dark', isDark);
-      localStorage.setItem('dark-mode', isDark ? 'true' : 'false');
-      updateIcon(isDark);
-    };
-    window.updateIcon = updateIcon;
-    window.setDarkMode = setDarkMode;
-    const initialDark = document.documentElement.classList.contains('dark');
-    if (initialDark) document.body.classList.add('dark');
-    updateIcon(initialDark);
-    btn.addEventListener('click', () => {
-      const currentlyDark = document.documentElement.classList.contains('dark');
-      setDarkMode(!currentlyDark);
-    });
-  })();
-  </script>
 </body>
 </html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -9,15 +9,8 @@
 {% block content %}
 
 <p class="text-sm text-center mb-4 text-gray-500 dark:text-gray-400">
-  Adjust your preferences below. Changes are saved locally in your browser.
+  No settings are currently available.
 </p>
-
-<form class="space-y-4" aria-label="Settings form">
-  <label for="dark-toggle" class="flex items-center space-x-2">
-    <input type="checkbox" id="dark-toggle">
-    <span>Use dark mode</span>
-  </label>
-</form>
 
 <footer class="w-full max-w-md mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
@@ -32,31 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
       el.style.opacity = 1;
     });
   }
-  const toggle = document.getElementById('dark-toggle');
-  if (toggle) {
-    const stored = localStorage.getItem('dark-mode');
-    if (stored === 'true' ||
-        (stored === null && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-      toggle.checked = true;
-    }
-    toggle.addEventListener('change', () => {
-      if (typeof window.setDarkMode === 'function') {
-        window.setDarkMode(toggle.checked);
-      } else {
-        if (toggle.checked) {
-          document.documentElement.classList.add('dark');
-          localStorage.setItem('dark-mode', 'true');
-        } else {
-          localStorage.removeItem('dark-mode');
-          if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            document.documentElement.classList.add('dark');
-          } else {
-            document.documentElement.classList.remove('dark');
-          }
-        }
-      }
-    });
-  }
+  // no settings to initialize
 });
 </script>
 


### PR DESCRIPTION
## Summary
- simplify dark mode handling to always follow system preference
- drop dark-mode toggle button and settings option
- clean up docs referencing the toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6345dd3883328d513ef01454aaa0