### PR TITLE
Add button borders in markdown toolbar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -143,7 +143,8 @@ textarea.journal-textarea:focus {
 }
 .md-btn {
   background: none;
-  border: none;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
   color: var(--editor-toolbar-color, #ccc);
   cursor: pointer;
   padding: 0.4rem 0.6rem;
@@ -153,7 +154,7 @@ textarea.journal-textarea:focus {
 }
 .dark .markdown-toolbar .md-btn {
   background-color: #4b5563;
-  border-color: #6b7280;
+  border: 1px solid #6b7280;
   color: #f5f5f5;
 }
 .dark .markdown-toolbar .md-btn:hover {


### PR DESCRIPTION
## Summary
- add borders and rounding to markdown toolbar buttons for improved clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f666661848332b98b3346b3cff516