### PR TITLE
Adjust journal content width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -32,8 +32,8 @@ body {
 }
 textarea.journal-textarea {
   display: block;
-  width: 90%;
-  max-width: 90%;
+  width: 100%;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
   min-height: 6rem;
@@ -69,8 +69,8 @@ textarea.journal-textarea {
 
 .journal-html {
   display: block;
-  width: 90%;
-  max-width: 90%;
+  width: 100%;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
   padding: 1.5rem;

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -35,7 +35,7 @@
     rows="4"
   >{{ content }}</textarea>
   {% else %}
-    <div class="journal-html w-[90%] max-w-[90%] mx-auto p-6 font-serif rounded-xl shadow prose dark:prose-invert prose-lg">
+    <div class="journal-html mx-auto p-6 font-serif rounded-xl shadow prose dark:prose-invert prose-lg">
     {{ content_html|safe }}</div>
   {% endif %}
 </section>


### PR DESCRIPTION
## Summary
- remove inline 90% width on archived entry container
- expand `.journal-textarea` and `.journal-html` to full width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f67a5190883328249593336bd77c4