### PR TITLE
Fix prompt animation spacing

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -58,21 +58,30 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!target) return 0;
     const text = target.textContent.trim();
     target.textContent = "";
-    const frag = document.createDocumentFragment();
-    [...text].forEach((char, idx) => {
+
+    let delay = startDelay;
+    const tokens = text.split(/(\s+)/);
+
+    tokens.forEach((token) => {
+      if (/^\s+$/.test(token)) {
+        target.appendChild(document.createTextNode(token));
+        return;
+      }
+
       const span = document.createElement('span');
-      // Preserve spaces when animating character fade-in
-      span.textContent = char === ' ' ? '\u00A0' : char;
-      span.className = 'inline-block opacity-0 transition-opacity duration-300';
-      span.style.transitionDelay = `${startDelay + idx * 60}ms`;
-      frag.appendChild(span);
+      span.textContent = token;
+      span.className = 'inline-block opacity-0 transition-opacity duration-200';
+      span.style.transitionDelay = `${delay}ms`;
+      delay += 120;
+      target.appendChild(span);
     });
-    target.appendChild(frag);
+
     target.classList.remove('opacity-0');
     requestAnimationFrame(() => {
-      target.querySelectorAll('span').forEach(span => span.classList.add('opacity-100'));
+      target.querySelectorAll('span').forEach((span) => span.classList.add('opacity-100'));
     });
-    return startDelay + text.length * 60;
+
+    return delay;
   };
 
   const welcomeEl = document.getElementById("welcome-message");


### PR DESCRIPTION
## Summary
- animate prompt by word to avoid mid-word line breaks and speed up fade-in

## Checklist
- [x] Tests pass (`pytest`)
- [x] Code is formatted with `black` and linted with `pylint`
- [x] Documentation updated if needed

------
https://chatgpt.com/codex/tasks/task_e_687f6b051c708332a25adb3b35cc2c17