### PR TITLE
Fix header wrap on mobile

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
-  <header class="flex justify-between items-center w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto mb-4 sticky top-0 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100 z-10">
+  <header class="flex flex-col sm:flex-row justify-between items-center space-y-2 sm:space-y-0 w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto mb-4 sticky top-0 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100 z-10">
     {% block header_title %}
     <h1 class="welcome-message">Echo Journal</h1>
     {% endblock %}

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -3,7 +3,7 @@
 {% block title %}Echo Journal{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 whitespace-nowrap"
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0"
       {% if not readonly %} data-dynamic-greeting="true"{% endif %}>
     {% if readonly %}
       Welcome back to {{ date }}


### PR DESCRIPTION
## Summary
- allow header to stack vertically on small screens
- let welcome message wrap if needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6cac024483329c971794662ae8ad