### PR TITLE
Fix toolbar spacing and color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -118,15 +118,15 @@ textarea.journal-textarea:focus {
   transform: translateX(-50%);
   display: none;
   justify-content: center;
-  gap: 0.5rem;
-  background-color: #f0f0f0;
+  gap: 0.25rem;
+  background-color: #f0f4f8;
   width: max-content;
 }
 .editor-container:focus-within .markdown-toolbar {
     display: flex;
 }
 .dark .markdown-toolbar {
-  background-color: #4b5563;
+  background-color: #374151;
 }
 .editor-container {
   position: relative;


### PR DESCRIPTION
## Summary
- tweak markdown toolbar gap
- match toolbar background to editor area in dark and light themes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6d9238748332ad80fd18456c91cc