### PR TITLE
Improve archives layout and header animation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -168,4 +168,14 @@ textarea.journal-textarea:focus {
   color: #f87171;
 }
 
+@keyframes fadeInHeader {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.animate-fade-in {
+  animation: fadeInHeader 2s ease forwards;
+  animation-delay: 0.3s;
+}
+
 

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -3,7 +3,7 @@
 {% block title %}Echo Journal Archives{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 transition-opacity duration-[2000ms] delay-300">Archive</h1>
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 animate-fade-in">Archive</h1>
 {% endblock %}
 
 {% block content %}
@@ -14,26 +14,19 @@
 
 <div class="w-full mx-auto">
   {% for period, period_entries in entries.items() %}
-    <h2 class="text-lg font-medium mt-4">{{ period }}</h2>
-    <ul class="pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1 text-gray-800 dark:text-gray-100">
-      {% for entry_date, content in period_entries %}
-        <li class="py-1 border-b border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100">
-          <a href="/view/{{ entry_date }}" class="text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
-        — {{ content[:75] }}...
-        </li>
-      {% endfor %}
-    </ul>
+    <details class="mt-6 mb-4">
+      <summary class="cursor-pointer text-lg font-medium">{{ period }}</summary>
+      <ul class="mt-2 pl-4 border-l border-gray-300 dark:border-gray-600 space-y-2 text-gray-800 dark:text-gray-100">
+        {% for entry_date, content in period_entries %}
+          <li class="py-2 border-b border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100">
+            <a href="/view/{{ entry_date }}" class="block text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{ content[:75] }}...</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </details>
   {% endfor %}
 </div>
-<script>
-document.addEventListener("DOMContentLoaded", () => {
-  const el = document.getElementById("welcome-message");
-  if (el) {
-    requestAnimationFrame(() => {
-      el.style.opacity = 1;
-    });
-  }
-});
-</script>
+
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- animate archive page header using CSS
- group each month of entries in collapsible details element
- improve spacing and readability of entry list items
- add fade-in animation to global stylesheet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6e847d548332a43939a5a61e932f