### PR TITLE
Fix emoji rendering in welcome greeting

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -72,7 +72,7 @@ document.addEventListener("DOMContentLoaded", () => {
       wordSpan.style.whiteSpace = 'nowrap';
       wordSpan.style.display = 'inline-block';
 
-      token.split('').forEach((ch) => {
+      Array.from(token).forEach((ch) => {
         const letter = document.createElement('span');
         letter.textContent = ch;
         letter.className = 'letter-span inline-block opacity-0 transition-opacity duration-200';


### PR DESCRIPTION
## Summary
- avoid splitting emoji glyphs in dynamic welcome text

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fe6581b4083329e2c397f7e8086c3