### PR TITLE
Fix unhandled file read error in get_entry

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,14 +3,6 @@
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
 
-38. **File I/O errors not handled**
-   - `get_entry` opens files without catching `OSError`, so permission issues crash the server.
-   - Lines:
-     ```python
-     async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
-         content = await fh.read()
-     ```
-     【F:main.py†L158-L160】
 
 44. **Index route doesn't handle read errors**
    - If opening today's entry fails (permission denied etc.) the exception isn't caught and a 500 error occurs.

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -298,6 +298,18 @@ The following issues were identified and subsequently resolved.
          attributes=bleach.sanitizer.ALLOWED_ATTRIBUTES,
      )
      ```
-     【F:main.py†L307-L312】
+    【F:main.py†L307-L312】
+
+27. **File I/O errors not handled** (fixed)
+   - `get_entry` now catches `OSError` when reading entry files and returns a 500 error instead of crashing.
+   - Updated lines:
+     ```python
+     try:
+         async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
+             content = await fh.read()
+     except OSError as exc:
+         raise HTTPException(status_code=500, detail="Could not read entry") from exc
+     ```
+     【F:main.py†L160-L166】
 
 

--- a/main.py
+++ b/main.py
@@ -157,8 +157,11 @@ async def get_entry(entry_date: str):
     except ValueError as exc:
         raise HTTPException(status_code=404, detail="Entry not found") from exc
     if file_path.exists():
-        async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
-            content = await fh.read()
+        try:
+            async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
+                content = await fh.read()
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail="Could not read entry") from exc
         return {
             "date": entry_date,
             "content": content,


### PR DESCRIPTION
## Summary
- handle `OSError` when reading entry files in `get_entry`
- document the fix in `BUGS_FIXED.md`
- remove the open bug from `BUGS.md`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880005193f48332a5803651bd153d49