### PR TITLE
Fix lint error for aiofiles import

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-import aiofiles  # type: ignore
+import aiofiles  # type: ignore  # pylint: disable=import-error
 
 import pytest  # pylint: disable=import-error
 from fastapi.testclient import TestClient  # pylint: disable=import-error


### PR DESCRIPTION
## Summary
- silence pylint import-error for aiofiles in tests

## Checklist
- [x] Tests pass (`pytest`)
- [x] Code is formatted with `black` and linted with `pylint`
- [ ] Documentation updated if needed

------
https://chatgpt.com/codex/tasks/task_e_68800e4e3458833292a1577e91a2b6d2