### PR TITLE
Add request timing middleware and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,16 @@ running the app in other environments.
 
 ## Additional notes
 - Markdown files easily readable and portable
-- Designed for ultra-low friction daily journaling: 
+- Designed for ultra-low friction daily journaling:
   - ≤ 5s load time target
   - ≤ 1s save time target
 - Clean separation of UI, API, and storage logic
+
+## Monitoring request timings
+
+Each response includes an `X-Response-Time` header showing how long the request
+took. You can also visit the `/metrics` endpoint to see a JSON list of recent
+paths and their durations.
 
 ## Security considerations
 


### PR DESCRIPTION
## Summary
- log timing for each request
- expose `/metrics` endpoint with recent timings
- document how to inspect timings

## Checklist
- [x] Tests pass (`pytest`)
- [x] Code is formatted with `black` and linted with `pylint`
- [x] Documentation updated if needed

------
https://chatgpt.com/codex/tasks/task_e_68801b8d9f608332931baca42a791957