### PR TITLE
Fix view_entry empty sections bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,15 +5,6 @@ The following issues are still unresolved. Fixed bugs have been moved to [BUGS_F
 
 
 
-29. **Empty sections cause server error**
-   - `view_entry` raises a 500 error if either the prompt or entry section is empty even though index handles missing headers gracefully.
-   - Lines:
-     ```python
-     prompt, entry = parse_entry(md_content)
-     if not prompt or not entry:
-         raise HTTPException(status_code=500, detail="Malformed entry file")
-     ```
-     【F:main.py†L302-L305】
 
 31. **`load_entry` split assumes Unix newline**
    - The load_entry endpoint splits file contents using `"# Entry\n"`. Files created with Windows newlines (`\r\n`) or without a trailing newline won't parse correctly.

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -1,0 +1,13 @@
+# Fixed Bugs
+
+The following issues have been resolved.
+
+29. **Empty sections cause server error** (fixed)
+   - `view_entry` used to raise a 500 error if either the prompt or entry section was missing. The function now falls back to the raw content when both sections are absent.
+   - Fixed lines:
+     ```python
+     prompt, entry = parse_entry(md_content)
+     if not prompt and not entry:
+         entry = md_content.strip()
+     ```
+     【F:main.py†L350-L352】

--- a/main.py
+++ b/main.py
@@ -348,8 +348,8 @@ async def view_entry(request: Request, entry_date: str):
         raise HTTPException(status_code=500, detail="Could not read entry") from exc
 
     prompt, entry = parse_entry(md_content)
-    if not prompt or not entry:
-        raise HTTPException(status_code=500, detail="Malformed entry file")
+    if not prompt and not entry:
+        entry = md_content.strip()
 
     html_entry = markdown.markdown(entry)
     html_entry = bleach.clean(

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -132,10 +132,11 @@ def test_view_entry_multiline_prompt(test_client):
 
 
 def test_view_entry_malformed(test_client):
-    """Malformed files trigger a server error."""
+    """Malformed files are displayed as plain text without error."""
     (main.DATA_DIR / "bad.md").write_text("No headings here", encoding="utf-8")
     resp = test_client.get("/view/bad")
-    assert resp.status_code == 500
+    assert resp.status_code == 200
+    assert "No headings here" in resp.text
 
 
 def test_view_entry_missing(test_client):


### PR DESCRIPTION
## Summary
- handle missing prompt/entry sections in `view_entry`
- test that malformed entries display successfully
- document fixed bug

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688166c8fc948332a0c55e856dbce19d