### PR TITLE
Fix reverse geocode endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ import markdown
 import bleach
 
 import aiofiles
+import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles


### PR DESCRIPTION
## Summary
- import `httpx` for reverse geocoding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68820cb506488332b5681b7362f1b5e6