### PR TITLE
Add weather and location frontmatter on first save

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -167,13 +167,20 @@ if (saveButton) {
     const content = document.getElementById('journal-text').value;
     const date = "{{ date }}";
     const prompt = {{ prompt | tojson }};
+    const locEl = document.getElementById('location-display');
+    const location = locEl ? {
+      lat: parseFloat(locEl.dataset.lat || 0),
+      lon: parseFloat(locEl.dataset.lon || 0),
+      accuracy: parseFloat(locEl.dataset.accuracy || 0),
+      label: locEl.dataset.locationName || ''
+    } : null;
 
       const status = document.getElementById('save-status');
       try {
         const response = await fetch("/entry", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ date, content, prompt })
+          body: JSON.stringify({ date, content, prompt, location })
         });
 
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- capture geolocation details in the client when saving
- include location and current Open‑Meteo weather in YAML frontmatter
- persist existing frontmatter on subsequent saves

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688213d6de108332b6e12ae4a7a718d7