### PR TITLE
Refactor main.py into smaller modules

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import os
+
+# Allow overriding important paths via environment variables for easier testing
+# and deployment in restricted environments.
+APP_DIR = Path(os.getenv("APP_DIR", "/app"))
+DATA_DIR = Path(os.getenv("DATA_DIR", "/journals"))
+PROMPTS_FILE = Path(os.getenv("PROMPTS_FILE", str(APP_DIR / "prompts.json")))
+STATIC_DIR = Path(os.getenv("STATIC_DIR", str(APP_DIR / "static")))
+ENCODING = "utf-8"

--- a/file_utils.py
+++ b/file_utils.py
@@ -1,0 +1,69 @@
+"""Utility functions for reading and parsing journal entries."""
+
+from pathlib import Path
+import re
+from typing import List, Tuple, Optional
+
+import aiofiles
+
+from config import DATA_DIR, ENCODING
+
+
+def safe_entry_path(entry_date: str, data_dir: Path = DATA_DIR) -> Path:
+    """Return a normalized path for the given entry date inside ``data_dir``."""
+    sanitized = Path(entry_date).name
+    sanitized = re.sub(r"[^0-9A-Za-z_-]", "_", sanitized)
+    if not sanitized:
+        raise ValueError("Invalid entry date")
+    path = (data_dir / sanitized).with_suffix(".md")
+    # Ensure the path cannot escape ``data_dir``
+    try:
+        path.resolve().relative_to(data_dir.resolve())
+    except ValueError as exc:
+        raise ValueError("Invalid entry date") from exc
+    return path
+
+
+def parse_entry(md_content: str) -> Tuple[str, str]:
+    """Return (prompt, entry) sections from markdown without raising errors."""
+    prompt_lines: List[str] = []
+    entry_lines: List[str] = []
+    current_section = None
+    for line in md_content.splitlines():
+        stripped = line.strip()
+        if stripped == "# Prompt":
+            current_section = "prompt"
+            continue
+        if stripped == "# Entry":
+            current_section = "entry"
+            continue
+        if current_section == "prompt":
+            prompt_lines.append(line.rstrip())
+        elif current_section == "entry":
+            entry_lines.append(line.rstrip())
+
+    prompt = "\n".join(prompt_lines).strip()
+    entry = "\n".join(entry_lines).strip()
+    return prompt, entry
+
+
+def split_frontmatter(text: str) -> Tuple[Optional[str], str]:
+    """Return frontmatter and remaining content if present."""
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            fm = parts[1].strip()
+            body = parts[2].lstrip("\n")
+            return fm, body
+    return None, text
+
+
+async def read_existing_frontmatter(file_path: Path) -> Optional[str]:
+    """Return frontmatter from the given file path if present."""
+    try:
+        async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
+            existing = await fh.read()
+        frontmatter, _ = split_frontmatter(existing)
+        return frontmatter
+    except OSError:
+        return None

--- a/prompt_utils.py
+++ b/prompt_utils.py
@@ -1,0 +1,74 @@
+"""Prompt loading and generation helpers."""
+
+import asyncio
+import json
+import random
+from datetime import date
+from typing import Optional
+
+import aiofiles
+
+from config import PROMPTS_FILE, ENCODING
+
+_prompts_cache: Optional[dict] = None
+_prompts_lock = asyncio.Lock()
+
+
+async def load_prompts() -> dict:
+    """Load and cache journal prompts from PROMPTS_FILE."""
+    global _prompts_cache
+    if _prompts_cache is None:
+        async with _prompts_lock:
+            if _prompts_cache is None:
+                try:
+                    async with aiofiles.open(PROMPTS_FILE, "r", encoding=ENCODING) as fh:
+                        prompts_text = await fh.read()
+                    _prompts_cache = json.loads(prompts_text)
+                except (FileNotFoundError, json.JSONDecodeError):
+                    _prompts_cache = {}
+    return _prompts_cache
+
+
+def get_season(target_date: date) -> str:
+    """Return the season name for the given date."""
+    year = target_date.year
+    spring_start = date(year, 3, 1)
+    summer_start = date(year, 6, 1)
+    autumn_start = date(year, 9, 1)
+    winter_start = date(year, 12, 1)
+
+    if spring_start <= target_date < summer_start:
+        return "Spring"
+    if summer_start <= target_date < autumn_start:
+        return "Summer"
+    if autumn_start <= target_date < winter_start:
+        return "Autumn"
+    return "Winter"
+
+
+async def generate_prompt() -> dict:
+    """Select and return a prompt for the current day."""
+    today = date.today()
+    weekday = today.strftime("%A")
+    season = get_season(today)
+
+    prompts = await load_prompts()
+    if not prompts:
+        return {"category": None, "prompt": "Prompts file not found"}
+
+    categories_dict = prompts.get("categories")
+    if not isinstance(categories_dict, dict):
+        return {"category": None, "prompt": "No categories found"}
+
+    categories = list(categories_dict.keys())
+    if not categories:
+        return {"category": None, "prompt": "No categories found"}
+
+    category = random.choice(categories)
+    candidates = categories_dict.get(category, [])
+    if not candidates:
+        return {"category": category.capitalize(), "prompt": "No prompts in this category"}
+
+    prompt_template = random.choice(candidates)
+    prompt = prompt_template.replace("{{weekday}}", weekday).replace("{{season}}", season)
+    return {"category": category.capitalize(), "prompt": prompt}

--- a/weather_utils.py
+++ b/weather_utils.py
@@ -1,0 +1,42 @@
+"""Helpers for building frontmatter with optional weather data."""
+
+from typing import Optional
+
+import httpx
+
+
+async def fetch_weather(lat: float, lon: float) -> Optional[str]:
+    """Fetch current weather description from Open-Meteo."""
+    if lat == 0 and lon == 0:
+        return None
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {"latitude": lat, "longitude": lon, "current_weather": True}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            cw = data.get("current_weather", {})
+            temp = cw.get("temperature")
+            code = cw.get("weathercode")
+            if temp is not None and code is not None:
+                return f"{temp}°C code {code}"
+    except (httpx.HTTPError, ValueError):
+        return None
+    return None
+
+
+async def build_frontmatter(location: dict) -> str:
+    """Return a YAML frontmatter string based on the provided location."""
+    lat = float(location.get("lat") or 0)
+    lon = float(location.get("lon") or 0)
+    label = location.get("label") or ""
+    weather = await fetch_weather(lat, lon)
+
+    lines = []
+    if label:
+        lines.append(f"location: {label}")
+    if weather:
+        lines.append(f"weather: {weather}")
+    lines.append("photos: []")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- break up logic from `main.py` into standalone modules
- add `config.py` for shared constants
- implement `file_utils`, `prompt_utils`, and `weather_utils`
- update application to use helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882170882f88332991d4b7ac16c2a9c