### PR TITLE
Resolve pylint warnings and improve prompt caching

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+"""Core application paths and configuration constants."""
+
 from pathlib import Path
 import os
 

--- a/prompt_utils.py
+++ b/prompt_utils.py
@@ -4,29 +4,27 @@ import asyncio
 import json
 import random
 from datetime import date
-from typing import Optional
 
 import aiofiles
 
 from config import PROMPTS_FILE, ENCODING
 
-_prompts_cache: Optional[dict] = None
+_prompts_cache: dict = {"data": None}
 _prompts_lock = asyncio.Lock()
 
 
 async def load_prompts() -> dict:
-    """Load and cache journal prompts from PROMPTS_FILE."""
-    global _prompts_cache
-    if _prompts_cache is None:
+    """Load and cache journal prompts from ``PROMPTS_FILE``."""
+    if _prompts_cache["data"] is None:
         async with _prompts_lock:
-            if _prompts_cache is None:
+            if _prompts_cache["data"] is None:
                 try:
                     async with aiofiles.open(PROMPTS_FILE, "r", encoding=ENCODING) as fh:
                         prompts_text = await fh.read()
-                    _prompts_cache = json.loads(prompts_text)
+                    _prompts_cache["data"] = json.loads(prompts_text)
                 except (FileNotFoundError, json.JSONDecodeError):
-                    _prompts_cache = {}
-    return _prompts_cache
+                    _prompts_cache["data"] = {}
+    return _prompts_cache["data"]
 
 
 def get_season(target_date: date) -> str:


### PR DESCRIPTION
## Summary
- add a module docstring to `config.py`
- refactor `prompt_utils.load_prompts` to avoid the `global` statement and use a dict-based cache
- keep caching logic thread-safe with an asyncio lock

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pylint config.py file_utils.py prompt_utils.py weather_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688218e064ac83329a0130268b7eb22f