### PR TITLE
Fix lint jobs by installing dependencies

### DIFF
--- a/.github/workflows/auto-format-and-lint.yml
+++ b/.github/workflows/auto-format-and-lint.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Install Black and Pylint
       run: |
         pip install black pylint
+        pip install -r requirements.txt
 
     - name: Auto-format code using Black
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')


### PR DESCRIPTION
## Summary
- ensure Github Actions install the project's Python requirements before linting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b453436c8332bc38027c6e4afc41