### PR TITLE
Fix archive preview to show prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -218,7 +218,8 @@ async def archive_view(request: Request):
             # Skip unreadable files instead of failing the entire request
             continue
 
-        entries_by_month[month_key].append((entry_date.isoformat(), content))
+        prompt, _ = parse_entry(content)
+        entries_by_month[month_key].append((entry_date.isoformat(), prompt))
 
     # Sort months descending (latest first)
     sorted_entries = dict(sorted(entries_by_month.items(), reverse=True))

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -17,10 +17,10 @@
     <details class="mt-6 mb-4">
       <summary class="cursor-pointer text-lg font-medium">{{ period }}</summary>
       <ul class="mt-2 pl-4 border-l border-gray-300 dark:border-gray-600 space-y-2 text-gray-800 dark:text-gray-100">
-        {% for entry_date, content in period_entries %}
+        {% for entry_date, prompt in period_entries %}
           <li class="py-2 border-b border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100">
             <a href="/view/{{ entry_date }}" class="block text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
-            <span class="text-sm text-gray-600 dark:text-gray-400">{{ content[:75] }}...</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">{{ prompt[:75] }}...</span>
           </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Summary
- show prompts in archive previews instead of front matter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882bb83334483329e9c3f72bebb1269