### PR TITLE
Display archived entry metadata

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 import re
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Dict
 
 import aiofiles
 
@@ -67,3 +67,50 @@ async def read_existing_frontmatter(file_path: Path) -> Optional[str]:
         return frontmatter
     except OSError:
         return None
+
+
+def parse_frontmatter(frontmatter: str) -> Dict[str, str]:
+    """Return a dict of key/value pairs from a simple YAML frontmatter string."""
+    result: Dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+WEATHER_ICONS = {
+    0: "☀️",
+    1: "🌤️",
+    2: "⛅",
+    3: "☁️",
+    45: "🌫️",
+    48: "🌫️",
+    51: "🌦️",
+    53: "🌦️",
+    55: "🌦️",
+    61: "🌧️",
+    63: "🌧️",
+    65: "🌧️",
+    71: "❄️",
+    73: "❄️",
+    75: "❄️",
+    80: "🌦️",
+    81: "🌦️",
+    82: "🌧️",
+    95: "⛈️",
+    96: "⛈️",
+    99: "⛈️",
+}
+
+
+def format_weather(weather: str) -> str:
+    """Return a formatted weather string like ``☀️ 20°C`` from frontmatter."""
+    match = re.search(r"(-?\d+(?:\.\d+)?)°C code (\d+)", weather)
+    if not match:
+        return weather
+    temp = match.group(1)
+    code = int(match.group(2))
+    icon = WEATHER_ICONS.get(code, "")
+    return f"{icon} {temp}°C".strip()

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -40,9 +40,15 @@
   {% endif %}
 </section>
 <div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 mt-2 italic">
-  📍 Trying to detect your location...
+  {% if readonly and location %}
+    📍 {{ location }}
+  {% else %}
+    📍 Trying to detect your location...
+  {% endif %}
 </div>
-<div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic"></div>
+<div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic">
+  {% if readonly and weather %}{{ weather }}{% endif %}
+</div>
     {% if not readonly %}
   <section class="w-full mx-auto mt-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
     <button id="save-button" class="block w-[65%] max-w-[15rem] mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
@@ -298,7 +304,9 @@ async function fetchGeolocationDetails() {
   { enableHighAccuracy: true, timeout: 5000 });
 }
 
+{% if not readonly %}
 window.addEventListener("DOMContentLoaded", fetchGeolocationDetails);
+{% endif %}
 </script>
 
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -204,6 +204,23 @@ def test_view_entry_unreadable_file(test_client, monkeypatch):
     assert resp.status_code == 500
 
 
+def test_view_entry_uses_frontmatter(test_client):
+    """Location and weather come from frontmatter when viewing entries."""
+    content = (
+        "---\n"
+        "location: Testville\n"
+        "weather: 12\u00b0C code 1\n"
+        "photos: []\n"
+        "---\n"
+        "# Prompt\nP\n\n# Entry\nE"
+    )
+    (main.DATA_DIR / "2020-09-09.md").write_text(content, encoding="utf-8")
+    resp = test_client.get("/view/2020-09-09")
+    assert resp.status_code == 200
+    assert "Testville" in resp.text
+    assert "12\u00b0C" in resp.text
+
+
 def test_save_entry_invalid_date(test_client):
     """Entries with malformed date strings are still saved as-is."""
     payload = {"date": "2020-13-40", "content": "bad", "prompt": "p"}


### PR DESCRIPTION
## Summary
- show stored weather and location when viewing archived entries
- parse front matter for metadata
- skip geolocation lookups in view mode
- test that metadata appears for archived entries

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882be17f7948332b7ea0221c6743a90