### PR TITLE
Reduce markdown button padding

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -154,7 +154,7 @@ textarea.journal-textarea:focus {
   border-radius: 0.25rem;
   color: var(--editor-toolbar-color, #ccc);
   cursor: pointer;
-  padding: 0.4rem 0.6rem;
+  padding: 0.2rem 0.4rem;
 }
 .md-btn:hover {
   color: var(--accent-color, #fff);


### PR DESCRIPTION
## Summary
- tweak `.md-btn` padding for compact toolbar buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c056b8dc83329053742b7b86f2e9