### PR TITLE
Add stats dashboard

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,7 @@
     <nav class="space-x-4 text-sm" aria-label="Main navigation">
       <a href="/" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'home' %}font-semibold{% endif %}">Home</a>
       <a href="/archive" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'archive' %}font-semibold{% endif %}">Archive</a>
+      <a href="/stats" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'stats' %}font-semibold{% endif %}">Stats</a>
       <a href="/settings" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'settings' %}font-semibold{% endif %}">Settings</a>
     </nav>
   </header>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}Stats - Echo Journal{% endblock %}
+
+{% block header_title %}
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 transition-opacity duration-[2000ms] delay-300">Stats</h1>
+{% endblock %}
+
+{% block content %}
+<p class="text-sm text-center mb-4 text-gray-500 dark:text-gray-400">
+  Overview of your journaling activity.
+</p>
+
+<div class="space-y-4">
+  <p class="text-lg">Total entries: {{ stats.total_entries }}</p>
+  <p class="text-lg">Total words: {{ stats.total_words }}</p>
+  <p class="text-lg">Average words per entry: {{ stats.average_words }}</p>
+
+  <details open>
+    <summary class="cursor-pointer font-semibold">By Year</summary>
+    <ul class="mt-2 pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1">
+      {% for period, count in stats.years %}
+      <li>{{ period }}: {{ count }}</li>
+      {% endfor %}
+    </ul>
+  </details>
+
+  <details>
+    <summary class="cursor-pointer font-semibold">By Month</summary>
+    <ul class="mt-2 pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1">
+      {% for period, count in stats.months %}
+      <li>{{ period }}: {{ count }}</li>
+      {% endfor %}
+    </ul>
+  </details>
+
+  <details>
+    <summary class="cursor-pointer font-semibold">By Week</summary>
+    <ul class="mt-2 pl-4 border-l border-gray-300 dark:border-gray-600 space-y-1">
+      {% for period, count in stats.weeks %}
+      <li>{{ period }}: {{ count }}</li>
+      {% endfor %}
+    </ul>
+  </details>
+</div>
+
+<footer class="w-full max-w-md mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug">
+  <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
+  Echo Journal
+</footer>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("welcome-message");
+  if (el) {
+    requestAnimationFrame(() => {
+      el.style.opacity = 1;
+    });
+  }
+});
+</script>
+{% endblock %}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -257,3 +257,24 @@ def test_load_entry_empty_date(test_client):
     """Empty entry_date should return a 404 error."""
     resp = test_client.get("/entry", params={"entry_date": ""})
     assert resp.status_code == 404
+
+
+def test_stats_page_counts(test_client):
+    """Stats page aggregates entry and word counts."""
+    (main.DATA_DIR / "2022-01-01.md").write_text(
+        "# Prompt\nP\n\n# Entry\none two",
+        encoding="utf-8",
+    )
+    (main.DATA_DIR / "2022-01-02.md").write_text(
+        "# Prompt\nP\n\n# Entry\nthree",
+        encoding="utf-8",
+    )
+    (main.DATA_DIR / "2022-02-01.md").write_text(
+        "# Prompt\nP\n\n# Entry\nfour five six",
+        encoding="utf-8",
+    )
+
+    resp = test_client.get("/stats")
+    assert resp.status_code == 200
+    assert "Total entries: 3" in resp.text
+    assert "Total words: 6" in resp.text


### PR DESCRIPTION
## Summary
- create statistics template
- add Stats link to navigation
- compute entry and word counts for dashboard
- test stats dashboard

## Testing
- `black . --quiet`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688354362a7483328acc5a6395d7faf0