### PR TITLE
Improve archive layout responsiveness

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -16,10 +16,10 @@
   {% for period, period_entries in entries.items() %}
     <details class="mt-6 mb-4">
       <summary class="cursor-pointer text-lg font-medium">{{ period }}</summary>
-      <ul class="mt-2 pl-4 border-l border-gray-300 dark:border-gray-600 space-y-2 text-gray-800 dark:text-gray-100">
+      <ul class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-2 text-gray-800 dark:text-gray-100">
         {% for entry_date, prompt in period_entries %}
-          <li class="py-2 border-b border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100">
-            <a href="/view/{{ entry_date }}" class="block text-sm text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
+          <li class="py-2 border-b border-gray-300 dark:border-gray-600 sm:border-none">
+            <a href="/view/{{ entry_date }}" class="block text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
             <span class="text-sm text-gray-600 dark:text-gray-400">{{ prompt[:75] }}...</span>
           </li>
         {% endfor %}


### PR DESCRIPTION
## Summary
- add responsive grid layout in `archives.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835cb41d5483329c07b5c4c66f15d7