### PR TITLE
Compact archive layout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ This list captures planned work from the project roadmap. Completed items from e
 - [ ] **Expanded Archive view**
   - [X] Display metadata markers (location, weather, photo indicator)
   - [ ] Optional sorting and filtering by available enrichment
-  - [ ] Rework Archive page layout to be more compact.
+  - [X] Rework Archive page layout to be more compact.
 
 - [ ] **Stats dashboard**
   - [ ] Show entry counts by week, month and year

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -14,13 +14,13 @@
 
 <div class="w-full mx-auto">
   {% for period, period_entries in entries.items() %}
-    <details class="mt-6 mb-4">
-      <summary class="cursor-pointer text-lg font-medium">{{ period }}</summary>
-      <ul class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-2 text-gray-800 dark:text-gray-100">
+    <details class="mt-3 mb-2">
+      <summary class="cursor-pointer text-base font-medium">{{ period }}</summary>
+      <ul class="mt-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2 gap-y-1 text-gray-800 dark:text-gray-100">
         {% for entry_date, prompt in period_entries %}
-          <li class="py-2 border-b border-gray-300 dark:border-gray-600 sm:border-none">
-            <a href="/view/{{ entry_date }}" class="block text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">{{ entry_date }}</a>
-            <span class="text-sm text-gray-600 dark:text-gray-400">{{ prompt[:75] }}...</span>
+          <li class="py-1 border-b border-gray-300 dark:border-gray-600 sm:border-none flex items-center space-x-2">
+            <a href="/view/{{ entry_date }}" class="text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline whitespace-nowrap">{{ entry_date }}</a>
+            <span class="text-sm text-gray-600 dark:text-gray-400 truncate">{{ prompt[:75] }}...</span>
           </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Summary
- make archive layout tighter using flex grid and smaller spacing
- mark TODO item as done

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836512255883329840981b48be5c76