### PR TITLE
Ensure metadata displayed only for old entries

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -39,12 +39,10 @@
     {{ content_html|safe }}</div>
   {% endif %}
 </section>
-<div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 mt-2 italic {% if not (readonly and active_page == 'archive') %}hidden{% endif %}">
-  {% if readonly and active_page == 'archive' and location %}
-    📍 {{ location }}
-  {% endif %}
+<div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 mt-2 italic {% if not (readonly and active_page == 'archive' and location) %}hidden{% endif %}">
+  {% if readonly and active_page == 'archive' and location %}📍 {{ location }}{% endif %}
 </div>
-<div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not (readonly and active_page == 'archive') %}hidden{% endif %}">
+<div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not (readonly and active_page == 'archive' and weather) %}hidden{% endif %}">
   {% if readonly and active_page == 'archive' and weather %}{{ weather }}{% endif %}
 </div>
     {% if not readonly %}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -221,6 +221,19 @@ def test_view_entry_uses_frontmatter(test_client):
     assert "12\u00b0C" in resp.text
 
 
+def test_view_entry_no_metadata_hidden(test_client):
+    """Location and weather divs are hidden without metadata."""
+    (main.DATA_DIR / "2020-09-10.md").write_text(
+        "# Prompt\nP\n\n# Entry\nE", encoding="utf-8"
+    )
+    resp = test_client.get("/view/2020-09-10")
+    assert resp.status_code == 200
+    assert 'id="location-display"' in resp.text
+    assert 'hidden' in resp.text.split('id="location-display"')[1].split('>')[0]
+    assert 'id="weather-display"' in resp.text
+    assert 'hidden' in resp.text.split('id="weather-display"')[1].split('>')[0]
+
+
 def test_save_entry_invalid_date(test_client):
     """Entries with malformed date strings are still saved as-is."""
     payload = {"date": "2020-13-40", "content": "bad", "prompt": "p"}


### PR DESCRIPTION
## Summary
- hide weather and location info unless an archive entry provides them
- test that location/weather placeholders remain hidden when not present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836b1493008332abdd51b7ba01cc25