### PR TITLE
Fix toolbar button sizes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -154,7 +154,9 @@ textarea.journal-textarea:focus {
   border-radius: 0.25rem;
   color: var(--editor-toolbar-color, #ccc);
   cursor: pointer;
-  padding: 0.8rem 0.2rem;
+  padding: 0.2rem 0.4rem;
+  width: 2.5rem;
+  margin: 0.1rem 0;
 }
 .md-btn:hover {
   color: var(--accent-color, #fff);


### PR DESCRIPTION
## Summary
- ensure markdown formatting buttons share a consistent width
- keep margins compact so the toolbar stays tidy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837040dad48332965b90e50c014b67