### PR TITLE
Align header fade effect across pages

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,7 +3,7 @@
 {% block title %}Settings - Echo Journal{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 transition-opacity duration-[2000ms] delay-300">Settings</h1>
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0">Settings</h1>
 {% endblock %}
 
 {% block content %}
@@ -19,13 +19,49 @@
 
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-  const el = document.getElementById("welcome-message");
-  if (el) {
-    requestAnimationFrame(() => {
-      el.style.opacity = 1;
+  const animateText = (target, startDelay = 0, letterDelay = 80, wordDelay = 150) => {
+    if (!target) return 0;
+    const text = target.textContent.trim();
+    target.textContent = "";
+
+    let delay = startDelay;
+    const tokens = text.split(/(\s+)/);
+
+    tokens.forEach((token) => {
+      if (/^\s+$/.test(token)) {
+        target.appendChild(document.createTextNode(token));
+        return;
+      }
+
+      const wordSpan = document.createElement('span');
+      wordSpan.style.whiteSpace = 'nowrap';
+      wordSpan.style.display = 'inline-block';
+
+      Array.from(token).forEach((ch) => {
+        const letter = document.createElement('span');
+        letter.textContent = ch;
+        letter.className = 'letter-span inline-block opacity-0 transition-opacity duration-200';
+        letter.style.transitionDelay = `${delay}ms`;
+        delay += letterDelay;
+        wordSpan.appendChild(letter);
+      });
+
+      delay += wordDelay;
+      target.appendChild(wordSpan);
     });
+
+    target.classList.remove('opacity-0');
+    requestAnimationFrame(() => {
+      target.querySelectorAll('.letter-span').forEach((span) => span.classList.add('opacity-100'));
+    });
+
+    return delay;
+  };
+
+  const welcomeEl = document.getElementById("welcome-message");
+  if (welcomeEl) {
+    animateText(welcomeEl, 0, 60, 200);
   }
-  // no settings to initialize
 });
 </script>
 

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -3,7 +3,7 @@
 {% block title %}Stats - Echo Journal{% endblock %}
 
 {% block header_title %}
-  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0 animate-fade-in">Stats</h1>
+  <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0">Stats</h1>
 {% endblock %}
 
 {% block content %}
@@ -98,5 +98,53 @@
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   Echo Journal
 </footer>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const animateText = (target, startDelay = 0, letterDelay = 80, wordDelay = 150) => {
+    if (!target) return 0;
+    const text = target.textContent.trim();
+    target.textContent = "";
+
+    let delay = startDelay;
+    const tokens = text.split(/(\s+)/);
+
+    tokens.forEach((token) => {
+      if (/^\s+$/.test(token)) {
+        target.appendChild(document.createTextNode(token));
+        return;
+      }
+
+      const wordSpan = document.createElement('span');
+      wordSpan.style.whiteSpace = 'nowrap';
+      wordSpan.style.display = 'inline-block';
+
+      Array.from(token).forEach((ch) => {
+        const letter = document.createElement('span');
+        letter.textContent = ch;
+        letter.className = 'letter-span inline-block opacity-0 transition-opacity duration-200';
+        letter.style.transitionDelay = `${delay}ms`;
+        delay += letterDelay;
+        wordSpan.appendChild(letter);
+      });
+
+      delay += wordDelay;
+      target.appendChild(wordSpan);
+    });
+
+    target.classList.remove('opacity-0');
+    requestAnimationFrame(() => {
+      target.querySelectorAll('.letter-span').forEach((span) => span.classList.add('opacity-100'));
+    });
+
+    return delay;
+  };
+
+  const welcomeEl = document.getElementById("welcome-message");
+  if (welcomeEl) {
+    animateText(welcomeEl, 0, 60, 200);
+  }
+});
+</script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove CSS-only fade-in effects on settings and stats pages
- add dynamic letter fade-in animation to settings header
- add dynamic letter fade-in animation to stats header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837e1c7b2c8332ba201a11531e0e47