### PR TITLE
Fix stats page width by overriding main classes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,7 +39,7 @@
     </nav>
   </header>
 
-  <main class="prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
+  <main class="{% block main_classes %}prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}">
     {% block content %}{% endblock %}
   </main>
 </body>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -2,6 +2,8 @@
 
 {% block title %}Stats - Echo Journal{% endblock %}
 
+{% block main_classes %}w-full max-w-none mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
+
 {% block header_title %}
   <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0">Stats</h1>
 {% endblock %}


### PR DESCRIPTION
## Summary
- make `<main>` classes overridable in base template
- expand stats page width so its grid isn't constrained

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883963b221083329c519f8e9255f0c9