### PR TITLE
Fix stats grid width on large screens

### DIFF
--- a/templates/stats.html
+++ b/templates/stats.html
@@ -14,7 +14,7 @@
     Overview of your journaling activity.
   </p>
 
-  <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+  <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 w-full">
     <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
       <p class="text-lg">
         <span class="sr-only">Total entries: {{ stats.total_entries }}</span>


### PR DESCRIPTION
## Summary
- ensure stats grid expands full width by adding `w-full`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68839e5851b88332b12cf10963698095