### PR TITLE
Improve archive layout with cards

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -16,14 +16,14 @@
   {% for period, period_entries in entries.items() %}
     <details class="mt-3 mb-2">
       <summary class="cursor-pointer text-base font-medium">{{ period }}</summary>
-      <ul class="mt-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2 gap-y-1 text-gray-800 dark:text-gray-100">
+      <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-gray-800 dark:text-gray-100">
         {% for entry_date, prompt in period_entries %}
-          <li class="py-1 border-b border-gray-300 dark:border-gray-600 sm:border-none flex items-center space-x-2">
-            <a href="/view/{{ entry_date }}" class="text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline whitespace-nowrap">{{ entry_date }}</a>
-            <span class="text-sm text-gray-600 dark:text-gray-400 truncate">{{ prompt[:75] }}...</span>
-          </li>
+          <a href="/view/{{ entry_date }}" class="block p-4 rounded-xl bg-white dark:bg-[#333] shadow hover:shadow-md transition">
+            <p class="text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300">{{ entry_date }}</p>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1 truncate">{{ prompt[:75] }}...</p>
+          </a>
         {% endfor %}
-      </ul>
+      </div>
     </details>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- adjust archive entries to use a card grid similar to stats page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b3ddb17883329d2ceb7411ffab27