### PR TITLE
Show full prompts on archive page

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -18,9 +18,9 @@
       <summary class="cursor-pointer text-base font-medium">{{ period }}</summary>
       <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-gray-800 dark:text-gray-100">
         {% for entry_date, prompt in period_entries %}
-          <a href="/view/{{ entry_date }}" class="block p-4 rounded-xl bg-white dark:bg-[#333] shadow hover:shadow-md transition">
+          <a href="/view/{{ entry_date }}" class="block p-4 rounded-xl bg-white dark:bg-[#333] shadow hover:shadow-md transition no-underline">
             <p class="text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300">{{ entry_date }}</p>
-            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1 truncate">{{ prompt[:75] }}...</p>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">{{ prompt }}</p>
           </a>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary
- show full prompt text on archive page
- remove text underline from archive entry links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b5896eac8332a3eb1d60cf7b7089