### PR TITLE
Apply paper texture to archive and stats cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -148,6 +148,28 @@ textarea.journal-textarea:focus {
 .dark .editor-container {
   background-color: #374151;
 }
+
+.paper-card {
+  background-color: #f0f4f8;
+  color: #1f2937;
+  border: 1px solid #d1d5db;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  background-image: image-set(
+    url('/static/textures/paper-texture.avif') type('image/avif'),
+    url('/static/textures/paper-texture.webp') type('image/webp')
+  );
+  background-repeat: repeat;
+  background-size: 512px 512px;
+  background-blend-mode: multiply;
+}
+.dark .paper-card {
+  background-color: #374151;
+  color: #f5f5f5;
+  border-color: #4b5563;
+  box-shadow: 0 2px 6px rgba(255, 255, 255, 0.12);
+  background-blend-mode: multiply;
+}
 .md-btn {
   background: none;
   border: 1px solid #d1d5db;

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -18,7 +18,7 @@
       <summary class="cursor-pointer text-base font-medium">{{ period }}</summary>
       <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-gray-800 dark:text-gray-100">
         {% for entry_date, prompt in period_entries %}
-          <a href="/view/{{ entry_date }}" class="block p-4 rounded-xl bg-white dark:bg-[#333] shadow hover:shadow-md transition no-underline">
+          <a href="/view/{{ entry_date }}" class="block p-4 rounded-xl paper-card hover:shadow-md transition no-underline">
             <p class="text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300">{{ entry_date }}</p>
             <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">{{ prompt }}</p>
           </a>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -15,49 +15,49 @@
   </p>
 
   <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 w-full">
-    <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
+    <div class="p-4 rounded-xl paper-card text-center">
       <p class="text-lg">
         <span class="sr-only">Total entries: {{ stats.total_entries }}</span>
         <span class="text-[clamp(1.5rem,2vw+1rem,2rem)] font-semibold block">{{ stats.total_entries }}</span>
         <span class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400">Total entries</span>
       </p>
     </div>
-    <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
+    <div class="p-4 rounded-xl paper-card text-center">
       <p class="text-lg">
         <span class="sr-only">Total words: {{ stats.total_words }}</span>
         <span class="text-[clamp(1.5rem,2vw+1rem,2rem)] font-semibold block">{{ stats.total_words }}</span>
         <span class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400">Total words</span>
       </p>
     </div>
-    <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
+    <div class="p-4 rounded-xl paper-card text-center">
       <p class="text-lg">
         <span class="sr-only">Average words per entry: {{ stats.average_words }}</span>
         <span class="text-[clamp(1.5rem,2vw+1rem,2rem)] font-semibold block">{{ stats.average_words }}</span>
         <span class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400">Avg words/entry</span>
       </p>
     </div>
-    <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
+    <div class="p-4 rounded-xl paper-card text-center">
       <p class="text-lg">
         <span class="sr-only">Current daily streak: {{ stats.current_day_streak }}</span>
         <span class="text-[clamp(1.5rem,2vw+1rem,2rem)] font-semibold block">{{ stats.current_day_streak }}</span>
         <span class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400">Current daily streak</span>
       </p>
     </div>
-    <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
+    <div class="p-4 rounded-xl paper-card text-center">
       <p class="text-lg">
         <span class="sr-only">Longest daily streak: {{ stats.longest_day_streak }}</span>
         <span class="text-[clamp(1.5rem,2vw+1rem,2rem)] font-semibold block">{{ stats.longest_day_streak }}</span>
         <span class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400">Longest daily streak</span>
       </p>
     </div>
-    <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
+    <div class="p-4 rounded-xl paper-card text-center">
       <p class="text-lg">
         <span class="sr-only">Current weekly streak: {{ stats.current_week_streak }}</span>
         <span class="text-[clamp(1.5rem,2vw+1rem,2rem)] font-semibold block">{{ stats.current_week_streak }}</span>
         <span class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400">Current weekly streak</span>
       </p>
     </div>
-    <div class="p-4 rounded-xl bg-white dark:bg-[#333] shadow text-center">
+    <div class="p-4 rounded-xl paper-card text-center">
       <p class="text-lg">
         <span class="sr-only">Longest weekly streak: {{ stats.longest_week_streak }}</span>
         <span class="text-[clamp(1.5rem,2vw+1rem,2rem)] font-semibold block">{{ stats.longest_week_streak }}</span>


### PR DESCRIPTION
## Summary
- add `.paper-card` style using paper texture
- update archives page to use `.paper-card`
- update stats page to use `.paper-card`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bfadcc98833288cee6f41c9a79b8