### PR TITLE
Fix archive responsive width

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -2,6 +2,8 @@
 
 {% block title %}Echo Journal Archives{% endblock %}
 
+{% block main_classes %}w-full max-w-none mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
+
 {% block header_title %}
   <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0">Archive</h1>
 {% endblock %}


### PR DESCRIPTION
## Summary
- widen archive page container so archive cards can wrap in grids on large screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883cd63e4d48332bdc441f903c82b89