### PR TITLE
Fix width of stats and archive pages

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -2,7 +2,7 @@
 
 {% block title %}Echo Journal Archives{% endblock %}
 
-{% block main_classes %}w-full max-w-none mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
+{% block main_classes %}w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
 
 {% block header_title %}
   <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0">Archive</h1>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -2,7 +2,7 @@
 
 {% block title %}Stats - Echo Journal{% endblock %}
 
-{% block main_classes %}w-full max-w-none mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
+{% block main_classes %}w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
 
 {% block header_title %}
   <h1 id="welcome-message" class="font-serif font-bold text-[clamp(1.75rem,2vw+1rem,2.5rem)] text-center mb-2 opacity-0">Stats</h1>


### PR DESCRIPTION
## Summary
- limit width of `stats.html` and `archives.html` so layout matches other pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883cea23a1083329fe1d5900944f7b2