### PR TITLE
Enable sorting and filtering in archive view

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ running the app in other environments.
 - Text area for daily entry
 - Save writes entry as a Markdown file named after the date
 
+## Archive
+The `/archive` page lists past entries grouped by month.
+
+Query parameters:
+- `sort_by` – ordering of entries: `date` (default), `location`, `weather`, or `photos`.
+- `filter` – limit results to entries containing metadata. Use `has_location` or `has_weather`.
+
+Example: `/archive?sort_by=location&filter=has_location`.
+
 ## Additional notes
 - Markdown files easily readable and portable
 - Designed for ultra-low friction daily journaling:

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -10,19 +10,41 @@
 
 {% block content %}
 
-<p class="text-sm mt-1 mb-4 text-center text-gray-500 dark:text-gray-400">
+<p class="text-sm mt-1 mb-2 text-center text-gray-500 dark:text-gray-400">
   A gentle record of your days — grouped for easy reflection.
 </p>
+<form method="get" class="flex items-center justify-center gap-4 mb-4 text-sm">
+  <label>Sort by
+    <select name="sort_by" onchange="this.form.submit()" class="ml-1">
+      <option value="date" {% if sort_by == 'date' %}selected{% endif %}>Date</option>
+      <option value="location" {% if sort_by == 'location' %}selected{% endif %}>Location</option>
+      <option value="weather" {% if sort_by == 'weather' %}selected{% endif %}>Weather</option>
+      <option value="photos" {% if sort_by == 'photos' %}selected{% endif %}>Photos</option>
+    </select>
+  </label>
+  <label>Filter
+    <select name="filter" onchange="this.form.submit()" class="ml-1">
+      <option value="" {% if not filter_val %}selected{% endif %}>None</option>
+      <option value="has_location" {% if filter_val == 'has_location' %}selected{% endif %}>Has location</option>
+      <option value="has_weather" {% if filter_val == 'has_weather' %}selected{% endif %}>Has weather</option>
+    </select>
+  </label>
+</form>
 
 <div class="w-full mx-auto">
   {% for period, period_entries in entries.items() %}
     <details class="mt-3 mb-2">
       <summary class="cursor-pointer text-base font-medium">{{ period }}</summary>
       <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-gray-800 dark:text-gray-100">
-        {% for entry_date, prompt in period_entries %}
+        {% for entry_date, prompt, meta in period_entries %}
           <a href="/view/{{ entry_date }}" class="block p-4 rounded-xl paper-card hover:shadow-md transition no-underline">
             <p class="text-sm font-medium text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300">{{ entry_date }}</p>
             <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">{{ prompt }}</p>
+            <div class="text-xs mt-1">
+              {% if meta.location %}<span title="Location">📍</span>{% endif %}
+              {% if meta.weather %}<span title="Weather">☁️</span>{% endif %}
+              {% if meta.photos and meta.photos != '[]' %}<span title="Photos">📸</span>{% endif %}
+            </div>
           </a>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary
- add optional `sort_by` and `filter` parameters for `/archive`
- parse entry frontmatter while collecting archives
- support filtering and sorting logic
- expose sort/filter selectors and metadata icons in template
- document query parameters for the archive page
- extend endpoint tests for new options

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d5f07fcc8332a53bb51eaa03cf21