### PR TITLE
Add save time metadata to journal entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Minimalist, mobile-first journaling webapp designed for personal use with Docker
 - Archive view to browse past entries
 - Settings page placeholder for future options
 - Stats dashboard showing entry counts, word totals and streaks
+- Optional metadata saved with each entry, including location, weather and time of day
 
 ## Project structure
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ This list captures planned work from the project roadmap. Completed items from e
   - [X] Query a weather API for recent conditions
   - [ ] Pull a "Word of the Day" and add that to the journal
   - [ ] Pull a "Fact of the Day" and add that to the journal
-  - [ ] Record save time in front matter
+  - [X] Record save time in front matter
   - [ ] AI assisted prompts / "Need inspiration?" feature
   - [ ] Optional "New Prompt" link with hover/tap hint
   - [ ] Evaluate secure remote access options (auth or VPN/proxy)

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ from file_utils import (
     format_weather,
 )
 from prompt_utils import generate_prompt
-from weather_utils import build_frontmatter
+from weather_utils import build_frontmatter, time_of_day_label
 
 
 # Provide pathlib.Path.is_relative_to on Python < 3.9
@@ -142,6 +142,21 @@ async def save_entry(data: dict):
         frontmatter = await build_frontmatter(location)
     else:
         frontmatter = await read_existing_frontmatter(file_path)
+
+    # Update or add save_time field
+    label = time_of_day_label()
+    fm_lines: list[str] = []
+    if frontmatter:
+        fm_lines = frontmatter.splitlines()
+    updated = False
+    for i, line in enumerate(fm_lines):
+        if line.startswith("save_time:"):
+            fm_lines[i] = f"save_time: {label}"
+            updated = True
+            break
+    if not updated:
+        fm_lines.append(f"save_time: {label}")
+    frontmatter = "\n".join(fm_lines) if fm_lines else None
 
     md_body = f"# Prompt\n{prompt}\n\n# Entry\n{content}"
     if frontmatter is not None:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -71,6 +71,19 @@ def test_save_entry_and_retrieve(test_client):
     assert "prompt" in resp2.json()["content"]
 
 
+def test_save_entry_records_time(test_client, monkeypatch):
+    """Saving an entry records the time of day in frontmatter."""
+    import weather_utils  # import inside to allow monkeypatch
+
+    monkeypatch.setattr(weather_utils, "time_of_day_label", lambda: "Evening")
+    payload = {"date": "2020-01-03", "content": "entry", "prompt": "prompt"}
+    resp = test_client.post("/entry", json=payload)
+    assert resp.status_code == 200
+    file_path = main.DATA_DIR / "2020-01-03.md"
+    text = file_path.read_text(encoding="utf-8")
+    assert "save_time: Evening" in text
+
+
 def test_save_entry_missing_fields(test_client):
     """Saving with missing required fields should return an error."""
     resp = test_client.post("/entry", json={"date": "2020-01-02"})

--- a/weather_utils.py
+++ b/weather_utils.py
@@ -1,6 +1,7 @@
 """Helpers for building frontmatter with optional weather data."""
 
 from typing import Optional
+from datetime import datetime
 
 import httpx
 
@@ -26,6 +27,19 @@ async def fetch_weather(lat: float, lon: float) -> Optional[str]:
     return None
 
 
+def time_of_day_label(now: datetime | None = None) -> str:
+    """Return Morning/Afternoon/Evening/Night for the given time."""
+    dt = now or datetime.now()
+    hour = dt.hour
+    if 5 <= hour < 12:
+        return "Morning"
+    if 12 <= hour < 17:
+        return "Afternoon"
+    if 17 <= hour < 21:
+        return "Evening"
+    return "Night"
+
+
 async def build_frontmatter(location: dict) -> str:
     """Return a YAML frontmatter string based on the provided location."""
     lat = float(location.get("lat") or 0)
@@ -38,5 +52,6 @@ async def build_frontmatter(location: dict) -> str:
         lines.append(f"location: {label}")
     if weather:
         lines.append(f"weather: {weather}")
+    lines.append(f"save_time: {time_of_day_label()}")
     lines.append("photos: []")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- record time of day when saving an entry
- update TODO item for save time metadata
- describe metadata feature in README
- test save time frontmatter behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d80a3c9c8332858c68ed75c1b6ea