### PR TITLE
Fix archives dropdown styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -209,5 +209,29 @@ textarea.journal-textarea:focus {
   animation-delay: 0.3s;
 }
 
+select {
+  background-color: #f0f4f8;
+  color: #1f2937;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.375rem;
+}
+
+.dark select {
+  background-color: #374151;
+  color: #f5f5f5;
+  border-color: #4b5563;
+}
+
+summary::marker,
+summary::-webkit-details-marker {
+  color: #4b5563;
+}
+
+.dark summary::marker,
+.dark summary::-webkit-details-marker {
+  color: #f5f5f5;
+}
+
 
 .hidden { display: none; }

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -15,7 +15,7 @@
 </p>
 <form method="get" class="flex items-center justify-center gap-4 mb-4 text-sm">
   <label>Sort by
-    <select name="sort_by" onchange="this.form.submit()" class="ml-1">
+    <select name="sort_by" onchange="this.form.submit()" class="ml-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 border border-gray-300 dark:border-gray-600">
       <option value="date" {% if sort_by == 'date' %}selected{% endif %}>Date</option>
       <option value="location" {% if sort_by == 'location' %}selected{% endif %}>Location</option>
       <option value="weather" {% if sort_by == 'weather' %}selected{% endif %}>Weather</option>
@@ -23,7 +23,7 @@
     </select>
   </label>
   <label>Filter
-    <select name="filter" onchange="this.form.submit()" class="ml-1">
+    <select name="filter" onchange="this.form.submit()" class="ml-1 px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 border border-gray-300 dark:border-gray-600">
       <option value="" {% if not filter_val %}selected{% endif %}>None</option>
       <option value="has_location" {% if filter_val == 'has_location' %}selected{% endif %}>Has location</option>
       <option value="has_weather" {% if filter_val == 'has_weather' %}selected{% endif %}>Has weather</option>


### PR DESCRIPTION
## Summary
- style select tags and summary markers for dark mode
- update archives dropdowns with new styling classes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883da82622083328384cebb37d886a8