### PR TITLE
Add Wordnik word-of-the-day support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The application looks for the following optional variables:
 - `APP_DIR` – base directory for static assets and templates
 - `PROMPTS_FILE` – location of the prompts JSON file
 - `STATIC_DIR` – directory for static files served under `/static`
+- `WORDNIK_API_KEY` – API key used to fetch the Wordnik word of the day
 
 Defaults are suitable for Docker Compose but can be overridden when
 running the app in other environments.

--- a/config.py
+++ b/config.py
@@ -10,3 +10,4 @@ DATA_DIR = Path(os.getenv("DATA_DIR", "/journals"))
 PROMPTS_FILE = Path(os.getenv("PROMPTS_FILE", str(APP_DIR / "prompts.json")))
 STATIC_DIR = Path(os.getenv("STATIC_DIR", str(APP_DIR / "static")))
 ENCODING = "utf-8"
+WORDNIK_API_KEY = os.getenv("WORDNIK_API_KEY")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -84,6 +84,21 @@ def test_save_entry_records_time(test_client, monkeypatch):
     assert "save_time: Evening" in text
 
 
+def test_word_of_day_in_frontmatter(test_client, monkeypatch):
+    """Wordnik word of the day is saved in frontmatter when available."""
+    import weather_utils
+
+    async def fake_word():
+        return "serendipity"
+
+    monkeypatch.setattr(weather_utils, "fetch_word_of_day", fake_word)
+    payload = {"date": "2020-10-10", "content": "entry", "prompt": "prompt"}
+    resp = test_client.post("/entry", json=payload)
+    assert resp.status_code == 200
+    text = (main.DATA_DIR / "2020-10-10.md").read_text(encoding="utf-8")
+    assert "wotd: serendipity" in text
+
+
 def test_save_entry_missing_fields(test_client):
     """Saving with missing required fields should return an error."""
     resp = test_client.post("/entry", json={"date": "2020-01-02"})

--- a/weather_utils.py
+++ b/weather_utils.py
@@ -5,6 +5,8 @@ from datetime import datetime
 
 import httpx
 
+from wordnik_utils import fetch_word_of_day
+
 
 async def fetch_weather(lat: float, lon: float) -> Optional[str]:
     """Fetch current weather description from Open-Meteo."""
@@ -46,6 +48,7 @@ async def build_frontmatter(location: dict) -> str:
     lon = float(location.get("lon") or 0)
     label = location.get("label") or ""
     weather = await fetch_weather(lat, lon)
+    wotd = await fetch_word_of_day()
 
     lines = []
     if label:
@@ -53,5 +56,7 @@ async def build_frontmatter(location: dict) -> str:
     if weather:
         lines.append(f"weather: {weather}")
     lines.append(f"save_time: {time_of_day_label()}")
+    if wotd:
+        lines.append(f"wotd: {wotd}")
     lines.append("photos: []")
     return "\n".join(lines)

--- a/wordnik_utils.py
+++ b/wordnik_utils.py
@@ -1,0 +1,22 @@
+import os
+from typing import Optional
+import httpx
+
+WORDNIK_URL = "https://api.wordnik.com/v4/words.json/wordOfTheDay"
+
+async def fetch_word_of_day() -> Optional[str]:
+    """Return today's Wordnik word of the day if available."""
+    api_key = os.getenv("WORDNIK_API_KEY")
+    if not api_key:
+        return None
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(WORDNIK_URL, params={"api_key": api_key}, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            word = data.get("word")
+            if isinstance(word, str):
+                return word
+    except (httpx.HTTPError, ValueError):
+        return None
+    return None


### PR DESCRIPTION
## Summary
- include a function to fetch Wordnik's word of the day
- embed the word of the day in generated frontmatter
- expose `WORDNIK_API_KEY` in config and docs
- test that the word of the day is stored when saving an entry

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dcd9a5b8833292a784b61e67fc89