### PR TITLE
Add word of day display

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -44,6 +44,7 @@
               {% if meta.location %}<span title="Location">📍</span>{% endif %}
               {% if meta.weather %}<span title="Weather">☁️</span>{% endif %}
               {% if meta.photos and meta.photos != '[]' %}<span title="Photos">📸</span>{% endif %}
+              {% if meta.wotd %}<span title="Word of the day">📖</span>{% endif %}
             </div>
           </a>
         {% endfor %}

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -45,6 +45,9 @@
 <div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not (readonly and active_page == 'archive' and weather) %}hidden{% endif %}">
   {% if readonly and active_page == 'archive' and weather %}{{ weather }}{% endif %}
 </div>
+<div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not wotd %}hidden{% endif %}">
+  {% if wotd %}📖 {{ wotd }}{% endif %}
+</div>
     {% if not readonly %}
   <section class="w-full mx-auto mt-6 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
     <button id="save-button" class="block w-[65%] max-w-[15rem] mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -383,3 +383,33 @@ def test_archive_filter_and_sort(test_client):
     assert resp2.status_code == 200
     # When sorted by location, Atown (2021-07-03) should come before Btown
     assert resp2.text.find("2021-07-03") < resp2.text.find("2021-07-01")
+
+
+def test_view_entry_shows_wotd(test_client):
+    """Word of the day from frontmatter should appear in view page."""
+    content = (
+        "---\n"
+        "wotd: luminous\n"
+        "photos: []\n"
+        "---\n"
+        "# Prompt\nP\n\n# Entry\nE"
+    )
+    (main.DATA_DIR / "2021-08-01.md").write_text(content, encoding="utf-8")
+    resp = test_client.get("/view/2021-08-01")
+    assert resp.status_code == 200
+    assert "luminous" in resp.text
+
+
+def test_archive_shows_wotd_icon(test_client):
+    """Entries with a word of the day show an icon in the archive."""
+    content = (
+        "---\n"
+        "wotd: zephyr\n"
+        "photos: []\n"
+        "---\n"
+        "# Prompt\nP\n\n# Entry\nE"
+    )
+    (main.DATA_DIR / "2021-09-09.md").write_text(content, encoding="utf-8")
+    resp = test_client.get("/archive")
+    assert resp.status_code == 200
+    assert "📖" in resp.text


### PR DESCRIPTION
## Summary
- surface word of the day metadata when loading entries
- show word-of-the-day icon on archive cards
- display the word itself on entry pages
- test wotd display on views and archive

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e0159c888332947c329df34eb4a4