### PR TITLE
Add optional API env vars to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,7 @@ services:
       - ${JOURNALS_DIR:-/mnt/nas/journals}:/journals
     environment:
       - TZ=America/New_York
+      # Optional API keys for extra features
+      - WORDNIK_API_KEY=${WORDNIK_API_KEY:-}
+      - IMMICH_URL=${IMMICH_URL:-}
+      - IMMICH_API_KEY=${IMMICH_API_KEY:-}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -77,6 +77,7 @@ def test_save_entry_records_time(test_client, monkeypatch):
     """Saving an entry records the time of day in frontmatter."""
 
     monkeypatch.setattr(weather_utils, "time_of_day_label", lambda: "Evening")
+    monkeypatch.setattr(main, "time_of_day_label", lambda: "Evening")
     payload = {"date": "2020-01-03", "content": "entry", "prompt": "prompt"}
     resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expose WORDNIK and Immich environment variables in `docker-compose.yml`
- adjust tests to monkeypatch `main.time_of_day_label`

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f42a856483329c43c9d6eb7e7429