### PR TITLE
Fix test_immich_utils lint

### DIFF
--- a/tests/test_immich_utils.py
+++ b/tests/test_immich_utils.py
@@ -18,16 +18,23 @@ class FakeClient:
         return False
 
     async def post(self, url, json=None, headers=None, timeout=None):
+        """Record POST data and return a simple response object."""
+        _ = headers  # parameters kept for API parity
+        _ = timeout
         self.captured["url"] = url
         self.captured["json"] = json
 
         class Response:
+            """Bare-minimum response object for tests."""
+
             @staticmethod
             def raise_for_status():
-                pass
+                """Pretend the response was successful."""
+                return None
 
             @staticmethod
             def json():
+                """Return an empty payload like ``httpx.Response.json``."""
                 return []
 
         return Response()


### PR DESCRIPTION
## Summary
- add docstrings to FakeClient response methods
- mark unused arguments to satisfy pylint

## Testing
- `python3 -m pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884063741188332b5be7b4f70180312