### PR TITLE
Add logging for Immich API operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ environment:
 With these configured, saving **or viewing** an entry will fetch any photos
 from Immich that match the entry's date and store a companion JSON file
 alongside the Markdown entry.
+The interactions with Immich are logged using the `ej.immich` logger so you can
+see when requests are made and JSON files written.
 
 ## Daily workflow
 - Dynamic prompt rendered server-side via FastAPI + Jinja2 (`echo_journal.html`)


### PR DESCRIPTION
## Summary
- add logger in `immich_utils` for Immich API calls
- log when skipping fetch, calling the API, errors, and writing JSON files
- document Immich logging in the README

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68840ae64228833285a0be25f6ebcad4