### PR TITLE
Fix Immich photo metadata integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -178,7 +178,7 @@ async def save_entry(data: dict):
         async with aiofiles.open(file_path, "w", encoding=ENCODING) as fh:
             await fh.write(md_text)
 
-    await update_photo_metadata(file_path)
+    await update_photo_metadata(entry_date, file_path)
 
     return {"status": "success"}
 
@@ -311,7 +311,7 @@ async def view_entry(request: Request, entry_date: str):
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="Entry not found")
 
-    await update_photo_metadata(file_path)
+    await update_photo_metadata(entry_date, file_path)
 
     try:
         async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -417,13 +417,11 @@ def test_archive_shows_wotd_icon(test_client):
 
 def test_save_entry_adds_photo_metadata(test_client, monkeypatch):
     """Saving an entry stores photo metadata from Immich."""
-    async def fake_fetch(_date_str: str, _media_type: str = "IMAGE"):
+    async def fake_fetch(_date_str: str, media_type: str = "IMAGE"):
         return [
             {
-                "type": "IMAGE",
-                "url": "img1.jpg",
-                "thumb": "thumb1.jpg",
-                "caption": "A photo",
+                "id": "123",
+                "originalFileName": "img1.jpg",
             }
         ]
 
@@ -434,18 +432,16 @@ def test_save_entry_adds_photo_metadata(test_client, monkeypatch):
     json_path = main.DATA_DIR / "2023-01-01.photos.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))
-    assert data[0]["url"] == "img1.jpg"
+    assert data[0]["caption"] == "img1.jpg"
 
 
 def test_archive_shows_photo_icon(test_client, monkeypatch):
     """Entries with a companion photo file show an icon in the archive."""
-    async def fake_fetch(_date_str: str, _media_type: str = "IMAGE"):
+    async def fake_fetch(_date_str: str, media_type: str = "IMAGE"):
         return [
             {
-                "type": "IMAGE",
-                "url": "img1.jpg",
-                "thumb": "thumb1.jpg",
-                "caption": "A photo",
+                "id": "123",
+                "originalFileName": "img1.jpg",
             }
         ]
 
@@ -462,7 +458,7 @@ def test_view_entry_updates_photo_metadata(test_client, monkeypatch):
     """Viewing an entry should poll Immich for new photos."""
     called = {"flag": False}
 
-    async def fake_update(_path):
+    async def fake_update(_date, _path):
         called["flag"] = True
 
     monkeypatch.setattr(main, "update_photo_metadata", fake_update)

--- a/tests/test_immich_utils.py
+++ b/tests/test_immich_utils.py
@@ -49,6 +49,6 @@ def test_fetch_assets_posts_search(monkeypatch):
 
     asyncio.run(immich_utils.fetch_assets_for_date("2025-07-19"))
 
-    assert client.captured["url"] == "http://example/api/asset/search"
+    assert client.captured["url"] == "http://example/api/search/metadata"
     assert client.captured["json"]["createdAt"]["min"] == "2025-07-19T00:00:00Z"
     assert client.captured["json"]["createdAt"]["max"] == "2025-07-19T23:59:59Z"


### PR DESCRIPTION
## Summary
- update calls to `update_photo_metadata` with date string
- adjust unit tests for updated function interface
- update Immich util test for new endpoint URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841de280fc83329ccc9485f85d9707