### PR TITLE
Expand Immich search range

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The application looks for the following optional variables:
 - `WORDNIK_API_KEY` – API key used to fetch the Wordnik word of the day
 - `IMMICH_URL` – base URL of your Immich API endpoint (for example `http://immich.local/api`)
 - `IMMICH_API_KEY` – API key used to authorize requests to Immich
+- `IMMICH_TIME_BUFFER` – hours to extend photo searches before and after each date (default `12`)
 
 Defaults are suitable for Docker Compose but can be overridden when
 running the app in other environments.
@@ -101,6 +102,8 @@ For a Docker Compose install, add them under the service's `environment` block:
 environment:
   - IMMICH_URL=http://immich.local/api
   - IMMICH_API_KEY=your_generated_token
+  # Optional: widen date searches by this many hours on either side
+  - IMMICH_TIME_BUFFER=12
 ```
 
 With these configured, saving **or viewing** an entry will fetch any photos

--- a/tests/test_immich_utils.py
+++ b/tests/test_immich_utils.py
@@ -50,5 +50,5 @@ def test_fetch_assets_posts_search(monkeypatch):
     asyncio.run(immich_utils.fetch_assets_for_date("2025-07-19"))
 
     assert client.captured["url"] == "http://example/api/search/metadata"
-    assert client.captured["json"]["createdAfter"] == "2025-07-19T00:00:00Z"
-    assert client.captured["json"]["createdBefore"] == "2025-07-19T23:59:59Z"
+    assert client.captured["json"]["createdAfter"] == "2025-07-18T12:00:00Z"
+    assert client.captured["json"]["createdBefore"] == "2025-07-20T11:59:59Z"


### PR DESCRIPTION
## Summary
- widen Immich API search window to account for timezone differences
- expose `IMMICH_TIME_BUFFER` env var in docs and default to 12 hours
- update Immich utility tests for new start/end times

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688423aa7d5c8332956da6df84ddad04