### PR TITLE
Improve Immich time buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The application looks for the following optional variables:
 - `WORDNIK_API_KEY` – API key used to fetch the Wordnik word of the day
 - `IMMICH_URL` – base URL of your Immich API endpoint (for example `http://immich.local/api`)
 - `IMMICH_API_KEY` – API key used to authorize requests to Immich
-- `IMMICH_TIME_BUFFER` – hours to extend photo searches before and after each date (default `12`)
+- `IMMICH_TIME_BUFFER` – hours to extend photo searches before and after each date (default `15`)
 
 Defaults are suitable for Docker Compose but can be overridden when
 running the app in other environments.
@@ -103,7 +103,7 @@ environment:
   - IMMICH_URL=http://immich.local/api
   - IMMICH_API_KEY=your_generated_token
   # Optional: widen date searches by this many hours on either side
-  - IMMICH_TIME_BUFFER=12
+  - IMMICH_TIME_BUFFER=15
 ```
 
 With these configured, saving **or viewing** an entry will fetch any photos

--- a/immich_utils.py
+++ b/immich_utils.py
@@ -13,8 +13,9 @@ from config import IMMICH_URL, IMMICH_API_KEY, ENCODING
 import os
 
 # Allow widening the search range so photos close to midnight in other
-# timezones are included. The default of 12 hours covers all time zones.
-IMMICH_TIME_BUFFER = int(os.getenv("IMMICH_TIME_BUFFER", "12"))
+# timezones are included. The default of 15 hours covers even the most
+# extreme differences from UTC.
+IMMICH_TIME_BUFFER = int(os.getenv("IMMICH_TIME_BUFFER", "15"))
 
 logger = logging.getLogger("ej.immich")
 

--- a/tests/test_immich_utils.py
+++ b/tests/test_immich_utils.py
@@ -50,5 +50,5 @@ def test_fetch_assets_posts_search(monkeypatch):
     asyncio.run(immich_utils.fetch_assets_for_date("2025-07-19"))
 
     assert client.captured["url"] == "http://example/api/search/metadata"
-    assert client.captured["json"]["createdAfter"] == "2025-07-18T12:00:00Z"
-    assert client.captured["json"]["createdBefore"] == "2025-07-20T11:59:59Z"
+    assert client.captured["json"]["createdAfter"] == "2025-07-18T09:00:00Z"
+    assert client.captured["json"]["createdBefore"] == "2025-07-20T14:59:59Z"


### PR DESCRIPTION
## Summary
- widen default Immich search window to 15 hours
- document new default in README
- adjust tests for new range

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688426e8116c83328abaa3cffea4340f