### PR TITLE
Add photo thumbnails in archive view

### DIFF
--- a/main.py
+++ b/main.py
@@ -332,6 +332,16 @@ async def archive_entry(request: Request, entry_date: str):
         attributes=bleach.sanitizer.ALLOWED_ATTRIBUTES,
     )
 
+    photos: list[dict] = []
+    json_path = file_path.with_suffix(".photos.json")
+    if json_path.exists():
+        try:
+            async with aiofiles.open(json_path, "r", encoding=ENCODING) as jh:
+                photos_text = await jh.read()
+            photos = json.loads(photos_text)
+        except (OSError, ValueError):
+            photos = []
+
     return templates.TemplateResponse(
         "archive-entry.html",
         {
@@ -343,6 +353,7 @@ async def archive_entry(request: Request, entry_date: str):
             "location": meta.get("location", ""),
             "weather": format_weather(meta["weather"]) if meta.get("weather") else "",
             "wotd": meta.get("wotd", ""),
+            "photos": photos,
             "readonly": True,  # Read-only mode for archive
             "active_page": "archive",
         },

--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -19,6 +19,13 @@
     {{ content_html|safe }}
   </div>
 </section>
+<div id="photos-display" class="mt-4 grid grid-cols-2 sm:grid-cols-3 gap-2 {% if not photos %}hidden{% endif %}">
+  {% for photo in photos %}
+  <a href="{{ photo.url }}" target="_blank" rel="noopener">
+    <img src="{{ photo.thumb }}" alt="{{ photo.caption }}" class="rounded shadow mx-auto">
+  </a>
+  {% endfor %}
+</div>
 <div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 mt-2 italic {% if not location %}hidden{% endif %}">
   {% if location %}📍 {{ location }}{% endif %}
 </div>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -472,3 +472,20 @@ def test_view_entry_updates_photo_metadata(test_client, monkeypatch):
     resp = test_client.get("/archive/2023-03-03")
     assert resp.status_code == 200
     assert called["flag"]
+
+
+def test_view_entry_shows_photos(test_client):
+    """Thumbnail images from photos.json are displayed on the entry page."""
+    md_path = main.DATA_DIR / "2023-04-04.md"
+    md_path.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
+    photos = [
+        {"url": "http://example.com/full1", "thumb": "http://example.com/t1", "caption": "one"},
+        {"url": "http://example.com/full2", "thumb": "http://example.com/t2", "caption": "two"},
+    ]
+    json_path = main.DATA_DIR / "2023-04-04.photos.json"
+    json_path.write_text(json.dumps(photos), encoding="utf-8")
+
+    resp = test_client.get("/archive/2023-04-04")
+    assert resp.status_code == 200
+    assert "http://example.com/t1" in resp.text
+    assert "http://example.com/t2" in resp.text


### PR DESCRIPTION
## Summary
- show thumbnails in `archive-entry.html`
- load `*.photos.json` metadata when rendering an archive entry
- test thumbnail display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c188610883329ed9ec189df9be2e