### PR TITLE
Fix asset links in archive

### DIFF
--- a/immich_utils.py
+++ b/immich_utils.py
@@ -83,7 +83,7 @@ async def update_photo_metadata(date_str: str, journal_path: Path) -> None:
         if not asset_id:
             continue
         photo_metadata.append({
-            "url": f"{IMMICH_URL}/assets/{asset_id}",
+            "url": f"/api/asset/{asset_id}",
             "thumb": f"/api/thumbnail/{asset_id}?size=medium",
             "caption": asset.get("originalFileName", "")
         })

--- a/main.py
+++ b/main.py
@@ -519,3 +519,17 @@ async def proxy_thumbnail(asset_id: str, size: str = "medium"):
     if resp.status_code != 200:
         raise HTTPException(status_code=resp.status_code, detail="Thumbnail fetch failed")
     return Response(content=resp.content, media_type="image/jpeg")
+
+
+@app.get("/api/asset/{asset_id}")
+async def proxy_asset(asset_id: str):
+    """Fetch a full-size asset from Immich using the API key."""
+    if not IMMICH_URL:
+        raise HTTPException(status_code=404, detail="Immich not configured")
+    headers = {"x-api-key": IMMICH_API_KEY} if IMMICH_API_KEY else {}
+    url = f"{IMMICH_URL}/assets/{asset_id}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, headers=headers)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail="Asset fetch failed")
+    return Response(content=resp.content, media_type=resp.headers.get("content-type", "application/octet-stream"))

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -434,6 +434,7 @@ def test_save_entry_adds_photo_metadata(test_client, monkeypatch):
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))
     assert data[0]["caption"] == "img1.jpg"
+    assert data[0]["url"] == "/api/asset/123"
     assert data[0]["thumb"] == "/api/thumbnail/123?size=medium"
 
 


### PR DESCRIPTION
## Summary
- proxy original image URLs through the app
- update photo metadata generator to use proxied path
- test that new path is stored in photos.json

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c8d6c1608332a0427d921c07e5e1