### PR TITLE
Fix line too long in asset proxy endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -532,4 +532,5 @@ async def proxy_asset(asset_id: str):
         resp = await client.get(url, headers=headers)
     if resp.status_code != 200:
         raise HTTPException(status_code=resp.status_code, detail="Asset fetch failed")
-    return Response(content=resp.content, media_type=resp.headers.get("content-type", "application/octet-stream"))
+    content_type = resp.headers.get("content-type", "application/octet-stream")
+    return Response(content=resp.content, media_type=content_type)


### PR DESCRIPTION
## Summary
- fix pylint issue in `proxy_asset` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ca338164833296081df6fd8becd9