### PR TITLE
Fix archive entry asset download

### DIFF
--- a/main.py
+++ b/main.py
@@ -527,7 +527,7 @@ async def proxy_asset(asset_id: str):
     if not IMMICH_URL:
         raise HTTPException(status_code=404, detail="Immich not configured")
     headers = {"x-api-key": IMMICH_API_KEY} if IMMICH_API_KEY else {}
-    url = f"{IMMICH_URL}/assets/{asset_id}"
+    url = f"{IMMICH_URL}/assets/{asset_id}/original"
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, headers=headers)
     if resp.status_code != 200:


### PR DESCRIPTION
## Summary
- fix Immich asset proxy to use `/original` download path
- ensure asset download is properly tested

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884cb738c7083328d86be977d1513f7