### PR TITLE
Fix Immich thumbnail parameter

### DIFF
--- a/immich_utils.py
+++ b/immich_utils.py
@@ -84,7 +84,7 @@ async def update_photo_metadata(date_str: str, journal_path: Path) -> None:
             continue
         photo_metadata.append({
             "url": f"/api/asset/{asset_id}",
-            "thumb": f"/api/thumbnail/{asset_id}?size=medium",
+            "thumb": f"/api/thumbnail/{asset_id}?size=thumbnail",
             "caption": asset.get("originalFileName", "")
         })
 

--- a/main.py
+++ b/main.py
@@ -508,7 +508,7 @@ async def reverse_geocode(lat: float, lon: float):
 
 
 @app.get("/api/thumbnail/{asset_id}")
-async def proxy_thumbnail(asset_id: str, size: str = "medium"):
+async def proxy_thumbnail(asset_id: str, size: str = "thumbnail"):
     """Fetch an asset thumbnail from Immich using the API key."""
     if not IMMICH_URL:
         raise HTTPException(status_code=404, detail="Immich not configured")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -435,7 +435,7 @@ def test_save_entry_adds_photo_metadata(test_client, monkeypatch):
     data = json.loads(json_path.read_text(encoding="utf-8"))
     assert data[0]["caption"] == "img1.jpg"
     assert data[0]["url"] == "/api/asset/123"
-    assert data[0]["thumb"] == "/api/thumbnail/123?size=medium"
+    assert data[0]["thumb"] == "/api/thumbnail/123?size=thumbnail"
 
 
 def test_archive_shows_photo_icon(test_client, monkeypatch):


### PR DESCRIPTION
## Summary
- use `thumbnail` size for Immich thumbnails
- adjust default thumbnail size in FastAPI endpoint
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d0bfb9208332be77cc3180a0cc34