### PR TITLE
Add photos filter option to archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The `/archive` page lists past entries grouped by month.
 
 Query parameters:
 - `sort_by` – ordering of entries: `date` (default), `location`, `weather`, or `photos`.
-- `filter` – limit results to entries containing metadata. Use `has_location` or `has_weather`.
+- `filter` – limit results to entries containing metadata. Use `has_location`, `has_weather`, or `has_photos`.
 
 Example: `/archive?sort_by=location&filter=has_location`.
 

--- a/main.py
+++ b/main.py
@@ -268,6 +268,12 @@ async def archive_view(
         all_entries = [e for e in all_entries if e["meta"].get("location")]
     elif filter_ == "has_weather":
         all_entries = [e for e in all_entries if e["meta"].get("weather")]
+    elif filter_ == "has_photos":
+        all_entries = [
+            e
+            for e in all_entries
+            if e["meta"].get("photos") not in (None, "[]")
+        ]
 
     if sort_by == "date":
         all_entries.sort(key=lambda e: e["date"], reverse=True)

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -27,6 +27,7 @@
       <option value="" {% if not filter_val %}selected{% endif %}>None</option>
       <option value="has_location" {% if filter_val == 'has_location' %}selected{% endif %}>Has location</option>
       <option value="has_weather" {% if filter_val == 'has_weather' %}selected{% endif %}>Has weather</option>
+      <option value="has_photos" {% if filter_val == 'has_photos' %}selected{% endif %}>Has photos</option>
     </select>
   </label>
 </form>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -385,6 +385,24 @@ def test_archive_filter_and_sort(test_client):
     assert resp2.text.find("2021-07-03") < resp2.text.find("2021-07-01")
 
 
+def test_archive_filter_has_photos(test_client):
+    """Entries can be filtered by those containing photos."""
+    md1 = main.DATA_DIR / "2024-01-01.md"
+    md1.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
+    photos_path = main.DATA_DIR / "2024-01-01.photos.json"
+    photos_path.write_text(
+        json.dumps([{"url": "u", "thumb": "t"}]), encoding="utf-8"
+    )
+
+    md2 = main.DATA_DIR / "2024-01-02.md"
+    md2.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
+
+    resp = test_client.get("/archive", params={"filter": "has_photos"})
+    assert resp.status_code == 200
+    assert "2024-01-01" in resp.text
+    assert "2024-01-02" not in resp.text
+
+
 def test_view_entry_shows_wotd(test_client):
     """Word of the day from frontmatter should appear in view page."""
     content = (


### PR DESCRIPTION
## Summary
- filter archive by photos
- document new photos filter in README
- show "Has photos" option in archive filter dropdown
- test archive photos filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d589aee8833289ba4f8baecf39f9