### PR TITLE
Resolve lint warnings

### DIFF
--- a/jellyfin_utils.py
+++ b/jellyfin_utils.py
@@ -47,14 +47,20 @@ async def fetch_top_songs(date_str: str) -> List[Dict[str, Any]]:
         if not played:
             continue
         try:
-            played_date = datetime.fromisoformat(played.replace("Z", "+00:00")).date()
+            if (
+                datetime.fromisoformat(played.replace("Z", "+00:00")).date().isoformat()
+                != date_str
+            ):
+                continue
         except ValueError:
             continue
-        if played_date.isoformat() != date_str:
-            continue
         name = item.get("Name", "Unknown Title")
-        artist_items = item.get("ArtistItems", [])
-        artist = " / ".join(a.get("Name", "Unknown Artist") for a in artist_items) or "Unknown Artist"
+        artist = (
+            " / ".join(
+                a.get("Name", "Unknown Artist") for a in item.get("ArtistItems", [])
+            )
+            or "Unknown Artist"
+        )
         todays_tracks.append((name, artist))
 
     counts = Counter(todays_tracks).most_common(5)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -6,15 +6,15 @@
 #
 # pylint: disable=redefined-outer-name
 
+import json
 import os
 import shutil
 import sys
 import tempfile
-from pathlib import Path
-import json
-import aiofiles  # type: ignore  # pylint: disable=import-error
 from datetime import datetime
+from pathlib import Path
 
+import aiofiles  # type: ignore  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error
 from fastapi.testclient import TestClient  # pylint: disable=import-error
 
@@ -366,7 +366,15 @@ def test_archive_filter_and_sort(test_client):
         "# Prompt\nP2\n\n# Entry\nE2"
     )
     entry3 = (
-        "---\n" "location: Atown\n" "photos: []\n" "---\n" "# Prompt\nP3\n\n# Entry\nE3"
+        """---
+location: Atown
+photos: []
+---
+# Prompt
+P3
+
+# Entry
+E3"""
     )
     (main.DATA_DIR / "2021-07-01.md").write_text(entry1, encoding="utf-8")
     (main.DATA_DIR / "2021-07-02.md").write_text(entry2, encoding="utf-8")
@@ -433,7 +441,15 @@ def test_archive_current_month_open(test_client):
 def test_view_entry_shows_wotd(test_client):
     """Word of the day from frontmatter should appear in view page."""
     content = (
-        "---\n" "wotd: luminous\n" "photos: []\n" "---\n" "# Prompt\nP\n\n# Entry\nE"
+        """---
+wotd: luminous
+photos: []
+---
+# Prompt
+P
+
+# Entry
+E"""
     )
     (main.DATA_DIR / "2021-08-01.md").write_text(content, encoding="utf-8")
     resp = test_client.get("/archive/2021-08-01")
@@ -444,7 +460,15 @@ def test_view_entry_shows_wotd(test_client):
 def test_archive_shows_wotd_icon(test_client):
     """Entries with a word of the day show an icon in the archive."""
     content = (
-        "---\n" "wotd: zephyr\n" "photos: []\n" "---\n" "# Prompt\nP\n\n# Entry\nE"
+        """---
+wotd: zephyr
+photos: []
+---
+# Prompt
+P
+
+# Entry
+E"""
     )
     (main.DATA_DIR / "2021-09-09.md").write_text(content, encoding="utf-8")
     resp = test_client.get("/archive")


### PR DESCRIPTION
## Summary
- clean up Jellyfin utils to reduce locals and shorten lines
- fix import ordering in tests
- rewrite multi-line strings in tests to avoid implicit concatenation

## Testing
- `pylint jellyfin_utils.py tests/test_endpoints.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884de11cacc8332b71fa1850eb3ce1c