### PR TITLE
Add backfill songs route

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ environment:
 When enabled, saving an entry writes a `<date>.songs.json` file listing up to
 five songs you played that day. Requests are logged with the `ej.jellyfin`
 logger.
+Existing journals can be retroactively populated using the `/api/backfill_songs`
+endpoint.
 
 ## Daily workflow
 - Dynamic prompt rendered server-side via FastAPI + Jinja2 (`echo_journal.html`)


### PR DESCRIPTION
## Summary
- implement `/api/backfill_songs` endpoint to create missing `songs.json`
- test that route generates song metadata
- document songs backfill endpoint in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884df412ff88332a57fcce23c1d375e