### PR TITLE
Add file logging and verbose song backfill logs

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,3 +16,7 @@ IMMICH_API_KEY = os.getenv("IMMICH_API_KEY")
 JELLYFIN_URL = os.getenv("JELLYFIN_URL")
 JELLYFIN_API_KEY = os.getenv("JELLYFIN_API_KEY")
 JELLYFIN_USER_ID = os.getenv("JELLYFIN_USER_ID")
+
+# File logging path - defaults to ``DATA_DIR/echo_journal.log`` but can
+# be overridden via the ``LOG_FILE`` environment variable.
+LOG_FILE = Path(os.getenv("LOG_FILE", str(DATA_DIR / "echo_journal.log")))


### PR DESCRIPTION
## Summary
- log to a file under DATA_DIR by default
- add detailed logging to Jellyfin song utilities
- log progress during song metadata backfills

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e287c36c8332844506f1dfd832ed