### PR TITLE
Display top songs in archive entry view

### DIFF
--- a/main.py
+++ b/main.py
@@ -362,6 +362,15 @@ async def archive_entry(request: Request, entry_date: str):
         except (OSError, ValueError):
             photos = []
 
+    songs: list[dict] = []
+    songs_path = file_path.with_suffix(".songs.json")
+    if songs_path.exists():
+        try:
+            async with aiofiles.open(songs_path, "r", encoding=ENCODING) as jh:
+                songs = json.loads(await jh.read())
+        except (OSError, ValueError):
+            songs = []
+
     return templates.TemplateResponse(
         "archive-entry.html",
         {
@@ -378,6 +387,7 @@ async def archive_entry(request: Request, entry_date: str):
             "weather": format_weather(meta["weather"]) if meta.get("weather") else "",
             "wotd": meta.get("wotd", ""),
             "photos": photos,
+            "songs": songs,
             "readonly": True,  # Read-only mode for archive
             "active_page": "archive",
         },

--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -32,10 +32,18 @@
 <div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not weather %}hidden{% endif %}">
   {% if weather %}{{ weather }}{% endif %}
 </div>
-<div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not wotd %}hidden{% endif %}">
-  {% if wotd %}📖 {{ wotd }}{% endif %}
-</div>
-<footer class="w-full mx-auto mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
+  <div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not wotd %}hidden{% endif %}">
+    {% if wotd %}📖 {{ wotd }}{% endif %}
+  </div>
+  <div id="songs-display" class="text-sm text-gray-600 dark:text-gray-300 mt-3 {% if not songs %}hidden{% endif %}">
+    <p class="font-medium mb-1">Top songs:</p>
+    <ol class="list-decimal list-inside">
+      {% for s in songs %}
+      <li>{{ s.track }} - {{ s.artist }} ({{ s.plays }})</li>
+      {% endfor %}
+    </ol>
+  </div>
+  <footer class="w-full mx-auto mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   Echo Journal
 </footer>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -605,6 +605,24 @@ def test_view_entry_shows_photos(test_client):
     assert "http://example.com/t2" in resp.text
 
 
+def test_view_entry_shows_songs(test_client):
+    """Song info from songs.json should appear on the entry page."""
+
+    md_path = main.DATA_DIR / "2023-07-07.md"
+    md_path.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
+    songs = [
+        {"track": "s1", "artist": "a1", "plays": 2},
+        {"track": "s2", "artist": "a2", "plays": 1},
+    ]
+    json_path = main.DATA_DIR / "2023-07-07.songs.json"
+    json_path.write_text(json.dumps(songs), encoding="utf-8")
+
+    resp = test_client.get("/archive/2023-07-07")
+    assert resp.status_code == 200
+    assert "s1" in resp.text
+    assert "a1" in resp.text
+
+
 def test_asset_proxy_download(test_client, monkeypatch):
     """Asset proxy endpoint should fetch original file from Immich."""
 


### PR DESCRIPTION
## Summary
- show songs in `archive-entry.html`
- provide songs from `songs.json` in `archive_entry` handler
- test that song info renders

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e4c2ab0c83328cb3f27bcf77b648