### PR TITLE
Fix Jellyfin date parsing

### DIFF
--- a/jellyfin_utils.py
+++ b/jellyfin_utils.py
@@ -54,7 +54,9 @@ async def fetch_top_songs(date_str: str) -> List[Dict[str, Any]]:
 
     todays_tracks: List[tuple[str, str]] = []
     for item in items:
-        played = item.get("DatePlayed")
+        played = item.get("DatePlayed") or item.get("UserData", {}).get(
+            "LastPlayedDate"
+        )
         if not played:
             continue
         try:

--- a/tests/test_jellyfin_utils.py
+++ b/tests/test_jellyfin_utils.py
@@ -1,0 +1,60 @@
+"""Tests for Jellyfin API utilities."""
+
+import asyncio
+
+import jellyfin_utils
+
+
+class FakeClient:
+    """Simplified httpx.AsyncClient mock for fetch_top_songs."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, headers=None, params=None, timeout=None):
+        _ = headers
+        _ = params
+        _ = timeout
+        self.url = url
+        class Response:
+            def __init__(self, items):
+                self._items = items
+            def raise_for_status(self):
+                return None
+            def json(self):
+                return {"Items": self._items}
+        items = [
+            {
+                "Name": "Song1",
+                "ArtistItems": [{"Name": "Artist1"}],
+                "UserData": {"LastPlayedDate": "2025-07-25T12:00:00Z"},
+            },
+            {
+                "Name": "Song1",
+                "ArtistItems": [{"Name": "Artist1"}],
+                "UserData": {"LastPlayedDate": "2025-07-25T13:00:00Z"},
+            },
+            {
+                "Name": "Song2",
+                "ArtistItems": [{"Name": "Artist2"}],
+                "UserData": {"LastPlayedDate": "2025-07-24T11:00:00Z"},
+            },
+        ]
+        return Response(items)
+
+
+def test_fetch_top_songs_lastplayed(monkeypatch):
+    """Items using LastPlayedDate should be counted."""
+    client = FakeClient()
+    monkeypatch.setattr(jellyfin_utils.httpx, "AsyncClient", lambda: client)
+    monkeypatch.setattr(jellyfin_utils, "JELLYFIN_URL", "http://example")
+    monkeypatch.setattr(jellyfin_utils, "JELLYFIN_USER_ID", "uid")
+
+    songs = asyncio.run(jellyfin_utils.fetch_top_songs("2025-07-25"))
+
+    assert songs[0]["track"] == "Song1"
+    assert songs[0]["artist"] == "Artist1"
+    assert songs[0]["plays"] == 2


### PR DESCRIPTION
## Summary
- parse `UserData.LastPlayedDate` from Jellyfin
- test new fallback for Jellyfin dates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e55d55508332a08deccee18ff3e4