### PR TITLE
Fix pylint issues in tests

### DIFF
--- a/tests/test_jellyfin_utils.py
+++ b/tests/test_jellyfin_utils.py
@@ -6,7 +6,11 @@ import jellyfin_utils
 
 
 class FakeClient:
-    """Simplified httpx.AsyncClient mock for fetch_top_songs."""
+    """Simplified ``httpx.AsyncClient`` mock for ``fetch_top_songs``."""
+
+    def __init__(self) -> None:
+        """Initialize the fake client with a blank ``url`` attribute."""
+        self.url = ""
 
     async def __aenter__(self):
         return self
@@ -15,17 +19,26 @@ class FakeClient:
         return False
 
     async def get(self, url, headers=None, params=None, timeout=None):
+        """Store request info and return a mock response."""
         _ = headers
         _ = params
         _ = timeout
         self.url = url
+
         class Response:
+            """Minimal ``httpx.Response`` stand-in."""
+
             def __init__(self, items):
                 self._items = items
+
             def raise_for_status(self):
+                """Pretend the request succeeded."""
                 return None
+
             def json(self):
+                """Return the payload in ``httpx`` style."""
                 return {"Items": self._items}
+
         items = [
             {
                 "Name": "Song1",


### PR DESCRIPTION
## Summary
- add missing docstrings to test helper class
- define URL attribute in FakeClient initializer to avoid pylint warning

## Testing
- `pylint $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e662aad48332a807f3e22deff195