### PR TITLE
Fix FakeClient initialization in tests

### DIFF
--- a/tests/test_jellyfin_utils.py
+++ b/tests/test_jellyfin_utils.py
@@ -8,15 +8,11 @@ import jellyfin_utils
 class FakeClient:
     """Simplified ``httpx.AsyncClient`` mock for ``fetch_top_songs``."""
 
-    def __init__(self) -> None:
-        """Initialize the fake client with a blank ``url`` attribute."""
+    def __init__(self, items=None) -> None:
+        """Initialize the fake client."""
         self.url = ""
-
-    def __init__(self, items=None):
-        self.items = items
-
-    def __init__(self):
         self.calls = []
+        self.items = items
 
     async def __aenter__(self):
         return self
@@ -44,25 +40,28 @@ class FakeClient:
             def json(self):
                 """Return the payload in ``httpx`` style."""
                 return {"Items": self._items}
-        start = int(params.get("StartIndex", 0))
-        limit = int(params.get("Limit", 0))
-        if start < 4:
-            items = [
-                {
-                    "Name": "Song1",
-                    "ArtistItems": [{"Name": "Artist1"}],
-                    "UserData": {"LastPlayedDate": "2025-07-25T12:00:00Z"},
-                }
-                for _ in range(limit)
-            ]
+        if self.items is not None:
+            items = self.items
         else:
-            items = [
-                {
-                    "Name": "Song2",
-                    "ArtistItems": [{"Name": "Artist2"}],
-                    "UserData": {"LastPlayedDate": "2025-07-24T11:00:00Z"},
-                }
-            ]
+            start = int(params.get("StartIndex", 0))
+            limit = int(params.get("Limit", 0))
+            if start < 4:
+                items = [
+                    {
+                        "Name": "Song1",
+                        "ArtistItems": [{"Name": "Artist1"}],
+                        "UserData": {"LastPlayedDate": "2025-07-25T12:00:00Z"},
+                    }
+                    for _ in range(limit)
+                ]
+            else:
+                items = [
+                    {
+                        "Name": "Song2",
+                        "ArtistItems": [{"Name": "Artist2"}],
+                        "UserData": {"LastPlayedDate": "2025-07-24T11:00:00Z"},
+                    }
+                ]
         return Response(items)
 
 


### PR DESCRIPTION
## Summary
- fix FakeClient initialization in tests
- allow passing custom items to FakeClient

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850002c47883329b56eebf071584d1