### PR TITLE
Refactor Jellyfin fetch and metadata helpers

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -1,8 +1,9 @@
 """Utility functions for reading and parsing journal entries."""
 
 from pathlib import Path
+import json
 import re
-from typing import List, Tuple, Optional, Dict
+from typing import Any, Dict, List, Optional, Tuple
 
 import aiofiles
 
@@ -78,6 +79,17 @@ def parse_frontmatter(frontmatter: str) -> Dict[str, str]:
         key, value = line.split(":", 1)
         result[key.strip()] = value.strip()
     return result
+
+
+async def load_json_file(file_path: Path) -> List[Dict[str, Any]]:
+    """Return parsed JSON data from ``file_path`` or an empty list."""
+    if not file_path.exists():
+        return []
+    try:
+        async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
+            return json.loads(await fh.read())
+    except (OSError, ValueError):
+        return []
 
 
 WEATHER_ICONS = {


### PR DESCRIPTION
## Summary
- add `load_json_file` helper for reading `.json` files
- use helper inside `archive_entry`
- refactor Jellyfin song fetch logic to reduce locals
- keep code formatted with black and pass pylint/pytest

## Testing
- `black --check jellyfin_utils.py file_utils.py main.py`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688500efba88833282bf29ce9fbb7d4b