### PR TITLE
Filter Immich photos by journal date

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -485,6 +485,7 @@ def test_save_entry_adds_photo_metadata(test_client, monkeypatch):
             {
                 "id": "123",
                 "originalFileName": "img1.jpg",
+                "fileCreatedAt": "2023-01-01T12:00:00Z",
             }
         ]
 
@@ -550,6 +551,7 @@ def test_archive_shows_photo_icon(test_client, monkeypatch):
             {
                 "id": "123",
                 "originalFileName": "img1.jpg",
+                "fileCreatedAt": "2023-02-02T08:00:00Z",
             }
         ]
 

--- a/tests/test_immich_utils.py
+++ b/tests/test_immich_utils.py
@@ -1,6 +1,7 @@
 """Tests for Immich API utilities."""
 
 import asyncio
+import json
 
 import immich_utils
 
@@ -52,3 +53,42 @@ def test_fetch_assets_posts_search(monkeypatch):
     assert client.captured["url"] == "http://example/api/search/metadata"
     assert client.captured["json"]["takenAfter"] == "2025-07-18T09:00:00Z"
     assert client.captured["json"]["takeBefore"] == "2025-07-20T14:59:59Z"
+
+
+def test_update_photo_metadata_filters_assets(monkeypatch, tmp_path):
+    """Only assets matching the journal date should be saved."""
+
+    assets = [
+        {
+            "id": "a1",
+            "originalFileName": "in-range.jpg",
+            "fileCreatedAt": "2025-07-19T10:00:00Z",
+        },
+        {
+            "id": "a2",
+            "originalFileName": "too-early.jpg",
+            "fileCreatedAt": "2025-07-18T23:59:00Z",
+        },
+        {
+            "id": "a3",
+            "originalFileName": "too-late.jpg",
+            "fileCreatedAt": "2025-07-20T00:00:00Z",
+        },
+    ]
+
+    async def fake_fetch(_date, media_type="IMAGE"):
+        _ = media_type
+        return assets
+
+    monkeypatch.setattr(immich_utils, "fetch_assets_for_date", fake_fetch)
+
+    md_path = tmp_path / "2025-07-19.md"
+    md_path.write_text("x", encoding="utf-8")
+
+    asyncio.run(immich_utils.update_photo_metadata("2025-07-19", md_path))
+
+    json_path = md_path.with_suffix(".photos.json")
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+
+    assert len(data) == 1
+    assert data[0]["caption"] == "in-range.jpg"


### PR DESCRIPTION
## Summary
- filter Immich API results by `fileCreatedAt`
- add unit test for date filtering
- adjust endpoint tests to provide creation date fields

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850e306148833298d7980f0c5f209a