### PR TITLE
Fix lint errors in imports and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 import json
 import logging
+from logging.handlers import RotatingFileHandler
 import time
 
 import aiofiles
@@ -22,7 +23,6 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from logging.handlers import RotatingFileHandler
 from config import (
     DATA_DIR,
     STATIC_DIR,

--- a/tests/test_immich_utils.py
+++ b/tests/test_immich_utils.py
@@ -1,7 +1,7 @@
 """Tests for Immich API utilities."""
 
 import asyncio
-import json
+import json as jsonlib
 
 import immich_utils
 
@@ -88,7 +88,7 @@ def test_update_photo_metadata_filters_assets(monkeypatch, tmp_path):
     asyncio.run(immich_utils.update_photo_metadata("2025-07-19", md_path))
 
     json_path = md_path.with_suffix(".photos.json")
-    data = json.loads(json_path.read_text(encoding="utf-8"))
+    data = jsonlib.loads(json_path.read_text(encoding="utf-8"))
 
     assert len(data) == 1
     assert data[0]["caption"] == "in-range.jpg"


### PR DESCRIPTION
## Summary
- reorder logging imports in `main.py` so `RotatingFileHandler` is grouped with standard library
- avoid redefined name warning in tests by aliasing the json module

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885120606cc8332a7f34efad8697d4c