### PR TITLE
Fix light mode toolbar colors

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -170,18 +170,19 @@ textarea.journal-textarea:focus {
   box-shadow: 0 2px 6px rgba(255, 255, 255, 0.12);
   background-blend-mode: multiply;
 }
-.md-btn {
-  background: none;
+.markdown-toolbar .md-btn {
+  background-color: #e5e7eb;
   border: 1px solid #d1d5db;
   border-radius: 0.25rem;
-  color: var(--editor-toolbar-color, #ccc);
+  color: #374151;
   cursor: pointer;
   padding: 0.2rem 0.4rem;
   width: 2.5rem;
   margin: 0.1rem 0;
 }
-.md-btn:hover {
-  color: var(--accent-color, #fff);
+.markdown-toolbar .md-btn:hover {
+  background-color: #d1d5db;
+  color: #1f2937;
 }
 .dark .markdown-toolbar .md-btn {
   background-color: #4b5563;


### PR DESCRIPTION
## Summary
- adjust toolbar button styles in light mode so they no longer appear washed out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68851fb8fda48332a28eb5ce7959fcc5