### PR TITLE
Responsive metadata panel

### DIFF
--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -15,31 +15,36 @@
   </div>
 </section>
 
-<section id="metadata" class="meta-card">
-  <div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 mt-2 italic {% if not location %}hidden{% endif %}">
-  {% if location %}📍 {{ location }}{% endif %}
-  </div>
-  <div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not weather %}hidden{% endif %}">
-  {% if weather %}{{ weather }}{% endif %}
-  </div>
-  <div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not wotd %}hidden{% endif %}">
-    {% if wotd %}📖 {{ wotd }}{% endif %}
-  </div>
-  <div id="songs-display" class="text-sm text-gray-600 dark:text-gray-300 mt-3 {% if not songs %}hidden{% endif %}">
-    🎵 <span class="font-medium">Today's Songs:</span>
-    <ul class="list-disc list-inside pl-4 mt-1">
-      {% for s in songs %}
-      <li>{{ s.track }} - {{ s.artist }}</li>
-      {% endfor %}
-    </ul>
-  </div>
-</section>
+<div id="entry-wrapper" class="md:flex md:items-start md:space-x-4">
+  <details id="metadata-panel" class="meta-card md:w-1/4">
+    <summary class="md:hidden cursor-pointer font-medium mb-2">Entry Metadata</summary>
+    <div class="space-y-1">
+      <div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 mt-2 italic {% if not location %}hidden{% endif %}">
+      {% if location %}📍 {{ location }}{% endif %}
+      </div>
+      <div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not weather %}hidden{% endif %}">
+      {% if weather %}{{ weather }}{% endif %}
+      </div>
+      <div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not wotd %}hidden{% endif %}">
+        {% if wotd %}📖 {{ wotd }}{% endif %}
+      </div>
+      <div id="songs-display" class="text-sm text-gray-600 dark:text-gray-300 mt-3 {% if not songs %}hidden{% endif %}">
+        🎵 <span class="font-medium">Today's Songs:</span>
+        <ul class="list-disc list-inside pl-4 mt-1">
+          {% for s in songs %}
+          <li>{{ s.track }} - {{ s.artist }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </details>
 
-<section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">
-  <div class="journal-html mx-auto p-6 font-serif rounded-xl prose dark:prose-invert prose-lg">
-    {{ content_html|safe }}
-  </div>
-</section>
+  <section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">
+    <div class="journal-html mx-auto p-6 font-serif rounded-xl prose dark:prose-invert prose-lg">
+      {{ content_html|safe }}
+    </div>
+  </section>
+</div>
 <section id="photos-display" class="mt-4 space-y-2">
 <div id="photos-display" class="meta-card {% if not photos %}hidden{% endif %}">
   <h2 class="text-sm font-medium text-gray-700 dark:text-gray-300">📷 Today's Photos</h2>
@@ -108,6 +113,19 @@ document.addEventListener("DOMContentLoaded", () => {
   if (promptEl) {
     animateText(promptEl, delay + 300, 15, 40);
   }
+
+  const metaPanel = document.getElementById("metadata-panel");
+  const mdWidth = 768;
+  const updateMetaPanel = () => {
+    if (!metaPanel) return;
+    if (window.innerWidth >= mdWidth) {
+      metaPanel.setAttribute("open", "");
+    } else {
+      metaPanel.removeAttribute("open");
+    }
+  };
+  updateMetaPanel();
+  window.addEventListener("resize", updateMetaPanel);
 });
 </script>
 


### PR DESCRIPTION
## Summary
- update archive entry template to handle responsive metadata panel
- open metadata by default on larger screens with JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854739e7f8833282cd8e314daa6048