### PR TITLE
Implement Jellyfin playback threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The application looks for the following optional variables:
 - `JELLYFIN_API_KEY` – optional API key for Jellyfin requests
 - `JELLYFIN_USER_ID` – Jellyfin user ID whose play history is queried
 - `JELLYFIN_PAGE_SIZE` – items to fetch per request when querying plays (default `200`)
+- `JELLYFIN_PLAY_THRESHOLD` – minimum percent played for a song to count (default `90`)
 - `LOG_LEVEL` – logging verbosity (default `DEBUG`)
 - `LOG_FILE` – path for the log file (default `DATA_DIR/echo_journal.log`)
 - `LOG_MAX_BYTES` – rotate the log after this many bytes (default `1048576`)
@@ -137,6 +138,7 @@ environment:
   - JELLYFIN_API_KEY=your_token
   - JELLYFIN_USER_ID=abcdef123456
   - JELLYFIN_PAGE_SIZE=200
+  - JELLYFIN_PLAY_THRESHOLD=90
 ```
 
 When enabled, saving an entry writes a `<date>.songs.json` file listing up to

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ IMMICH_API_KEY = os.getenv("IMMICH_API_KEY")
 JELLYFIN_URL = os.getenv("JELLYFIN_URL")
 JELLYFIN_API_KEY = os.getenv("JELLYFIN_API_KEY")
 JELLYFIN_USER_ID = os.getenv("JELLYFIN_USER_ID")
+JELLYFIN_PLAY_THRESHOLD = int(os.getenv("JELLYFIN_PLAY_THRESHOLD", "90"))
 
 # File logging path - defaults to ``DATA_DIR/echo_journal.log`` but can
 # be overridden via the ``LOG_FILE`` environment variable.


### PR DESCRIPTION
## Summary
- introduce `JELLYFIN_PLAY_THRESHOLD` variable
- ignore plays under the configured threshold
- document new environment variable
- test Jellyfin playback filtering

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854cf88cec8332a5c0dd920b0f0696