### PR TITLE
Expand song list display

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ environment:
 ```
 
 When enabled, saving an entry writes a `<date>.songs.json` file listing up to
-five songs you played that day. Requests are logged with the `ej.jellyfin`
+twenty songs you played that day. Requests are logged with the `ej.jellyfin`
 logger.
 Existing journals can be retroactively populated using the `/api/backfill_songs`
 endpoint.

--- a/jellyfin_utils.py
+++ b/jellyfin_utils.py
@@ -145,7 +145,7 @@ async def fetch_top_songs(date_str: str) -> List[Dict[str, Any]]:
             item[0][0].lower(),
             item[0][1].lower(),
         ),
-    )[:5]
+    )[:20]
     logger.info("Returning %d track records", len(sorted_counts))
     return [
         {"track": track, "artist": artist, "plays": cnt}

--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -28,14 +28,14 @@
       <div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not wotd %}hidden{% endif %}">
         {% if wotd %}📖 {{ wotd }}{% endif %}
       </div>
-      <div id="songs-display" class="text-sm text-gray-600 dark:text-gray-300 mt-3 {% if not songs %}hidden{% endif %}">
-        🎵 <span class="font-medium">Today's Songs:</span>
+      <details id="songs-display" class="text-sm text-gray-600 dark:text-gray-300 mt-3 {% if not songs %}hidden{% endif %}">
+        <summary class="cursor-pointer font-medium">🎵 Today's Songs</summary>
         <ul class="list-disc list-inside pl-4 mt-1">
           {% for s in songs %}
           <li>{{ s.track }} - {{ s.artist }}</li>
           {% endfor %}
         </ul>
-      </div>
+      </details>
     </div>
   </details>
 


### PR DESCRIPTION
## Summary
- store up to 20 Jellyfin tracks
- collapse song list by default in archive view
- document the 20-song limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688559b8c9288332904ff7a6e074a7e1