### PR TITLE
Add songs filter and sort in archive

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -20,6 +20,7 @@
       <option value="location" {% if sort_by == 'location' %}selected{% endif %}>Location</option>
       <option value="weather" {% if sort_by == 'weather' %}selected{% endif %}>Weather</option>
       <option value="photos" {% if sort_by == 'photos' %}selected{% endif %}>Photos</option>
+      <option value="songs" {% if sort_by == 'songs' %}selected{% endif %}>Songs</option>
     </select>
   </label>
   <label>Filter
@@ -28,6 +29,7 @@
       <option value="has_location" {% if filter_val == 'has_location' %}selected{% endif %}>Has location</option>
       <option value="has_weather" {% if filter_val == 'has_weather' %}selected{% endif %}>Has weather</option>
       <option value="has_photos" {% if filter_val == 'has_photos' %}selected{% endif %}>Has photos</option>
+      <option value="has_songs" {% if filter_val == 'has_songs' %}selected{% endif %}>Has songs</option>
     </select>
   </label>
 </form>
@@ -45,6 +47,7 @@
               {% if meta.location %}<span title="Location">📍</span>{% endif %}
               {% if meta.weather %}<span title="Weather">☁️</span>{% endif %}
               {% if meta.photos and meta.photos != '[]' %}<span title="Photos">📸</span>{% endif %}
+              {% if meta.songs %}<span title="Songs">🎵</span>{% endif %}
               {% if meta.wotd %}<span title="Word of the day">📖</span>{% endif %}
             </div>
           </a>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -625,6 +625,54 @@ def test_view_entry_shows_songs(test_client):
     assert "a1" in resp.text
 
 
+def test_archive_shows_song_icon(test_client):
+    """Entries with songs show an icon in the archive."""
+
+    md_path = main.DATA_DIR / "2024-02-02.md"
+    md_path.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
+    json_path = main.DATA_DIR / "2024-02-02.songs.json"
+    json_path.write_text(json.dumps([{"track": "t", "artist": "a"}]), encoding="utf-8")
+
+    resp = test_client.get("/archive")
+    assert resp.status_code == 200
+    assert "🎵" in resp.text
+
+
+def test_archive_filter_has_songs(test_client):
+    """Entries can be filtered by those containing songs."""
+
+    md1 = main.DATA_DIR / "2025-01-01.md"
+    md1.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
+    songs_path = main.DATA_DIR / "2025-01-01.songs.json"
+    songs_path.write_text(json.dumps([{"track": "t", "artist": "a"}]), encoding="utf-8")
+
+    md2 = main.DATA_DIR / "2025-01-02.md"
+    md2.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
+
+    resp = test_client.get("/archive", params={"filter": "has_songs"})
+    assert resp.status_code == 200
+    assert "2025-01-01" in resp.text
+    assert "2025-01-02" not in resp.text
+
+
+def test_archive_sort_by_songs(test_client):
+    """Entries can be sorted by songs metadata."""
+
+    md1 = main.DATA_DIR / "2026-01-01.md"
+    md1.write_text("# Prompt\nP1\n\n# Entry\nE1", encoding="utf-8")
+    path1 = main.DATA_DIR / "2026-01-01.songs.json"
+    path1.write_text(json.dumps([{"track": "b"}]), encoding="utf-8")
+
+    md2 = main.DATA_DIR / "2026-01-02.md"
+    md2.write_text("# Prompt\nP2\n\n# Entry\nE2", encoding="utf-8")
+    path2 = main.DATA_DIR / "2026-01-02.songs.json"
+    path2.write_text(json.dumps([{"track": "a"}]), encoding="utf-8")
+
+    resp = test_client.get("/archive", params={"sort_by": "songs"})
+    assert resp.status_code == 200
+    assert resp.text.find("2026-01-02") < resp.text.find("2026-01-01")
+
+
 def test_asset_proxy_download(test_client, monkeypatch):
     """Asset proxy endpoint should fetch original file from Immich."""
 


### PR DESCRIPTION
## Summary
- add songs icon plus filter/sort options to archives page
- detect songs metadata when building archive entries
- allow archive filtering and sorting by songs
- test new songs behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855ca15acc833297dc840ffc601bfa