### PR TITLE
Fix pylint too-many-locals

### DIFF
--- a/jellyfin_utils.py
+++ b/jellyfin_utils.py
@@ -104,10 +104,11 @@ async def fetch_top_songs(date_str: str) -> List[Dict[str, Any]]:
                 continue
             try:
                 play_dt = datetime.fromisoformat(played.replace("Z", "+00:00"))
-                play_date = play_dt.date().isoformat()
-                if play_date != date_str:
+                if play_dt.date().isoformat() != date_str:
                     logger.debug(
-                        "Skipping play dated %s (target %s)", play_date, date_str
+                        "Skipping play dated %s (target %s)",
+                        play_dt.date().isoformat(),
+                        date_str,
                     )
                     continue
             except ValueError:


### PR DESCRIPTION
## Summary
- keep pylint happy by reducing locals in `fetch_top_songs`

## Testing
- `pylint jellyfin_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885758c4b148332b1c77ef72c03f233