### PR TITLE
Add paper texture to meta-card areas

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -216,10 +216,18 @@ summary::-webkit-details-marker {
   color: #1f2937;
   border: 1px solid #e5e7eb;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  background-image: image-set(
+    url('/static/textures/paper-texture.avif') type('image/avif'),
+    url('/static/textures/paper-texture.webp') type('image/webp')
+  );
+  background-repeat: repeat;
+  background-size: 512px 512px;
+  background-blend-mode: multiply;
 }
 .dark .meta-card {
   background-color: #2b2d31;
   color: #f5f5f5;
   border-color: #3f4246;
   box-shadow: 0 1px 3px rgba(255, 255, 255, 0.1);
+  background-blend-mode: multiply;
 }


### PR DESCRIPTION
## Summary
- include paper background texture for metadata cards

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885ed385c4083329a0f87cfdd893c60