### PR TITLE
Fix meta-card style in light mode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -212,7 +212,7 @@ summary::-webkit-details-marker {
 .meta-card {
   border-radius: 0.75rem;
   padding: 1rem;
-  background-color: #f7f9fb;
+  background-color: #ffffff;
   color: #1f2937;
   border: 1px solid #e5e7eb;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
## Summary
- lighten the `meta-card` background so it's clearer against `paper-card`
- update CSS to make light mode cards more distinct

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886067ffe8083328775adedbd3a47d7