### PR TITLE
Fix missing location/weather placeholders

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -37,6 +37,11 @@
     <button id="save-button" class="block w-[65%] max-w-[15rem] mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>
 
+  <section class="w-full mx-auto text-center mt-2 space-y-1">
+    <div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 italic hidden"></div>
+    <div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 italic hidden"></div>
+  </section>
+
   <footer class="w-full mx-auto mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide" id="save-status" aria-live="polite" role="status">
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   {% if content %}Last saved: loaded from file{% else %}Last saved: no entry yet{% endif %} — Echo Journal


### PR DESCRIPTION
## Summary
- display hidden divs to capture location/weather on the edit page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b73db9f4833294d5efc8f69771b1