### PR TITLE
Fix newline parsing in load_entry

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -6,14 +6,6 @@ The following issues are still unresolved. Fixed bugs have been moved to [BUGS_F
 
 
 
-31. **`load_entry` split assumes Unix newline**
-   - The load_entry endpoint splits file contents using `"# Entry\n"`. Files created with Windows newlines (`\r\n`) or without a trailing newline won't parse correctly.
-   - Lines:
-     ```python
-     parts = content.split("# Entry\n", 1)
-     ```
-     【F:main.py†L181-L182】
-
 33. **Validation errors return HTTP 200**
    - `save_entry` returns an error object but still uses status code 200 when required fields are missing.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -395,7 +395,17 @@ The following issues were identified and subsequently resolved.
      replaced rather than appended.
    - Fixed lines:
      ```python
-     path = (data_dir / sanitized).with_suffix(".md")
+    path = (data_dir / sanitized).with_suffix(".md")
+    ```
+    【F:file_utils.py†L7-L13】
+
+44. **`load_entry` split assumes Unix newline** (fixed)
+   - The endpoint now parses files using `split_frontmatter` and `parse_entry`,
+     handling Windows newlines and missing trailing newlines.
+   - Fixed lines:
+     ```python
+     _, body = split_frontmatter(content)
+     entry_text = parse_entry(body)[1] or body.strip()
      ```
-     【F:file_utils.py†L7-L13】
+     【F:main.py†L250-L255】
 

--- a/README.md
+++ b/README.md
@@ -239,10 +239,10 @@ pylint $(git ls-files '*.py') --fail-under=8
 pytest
 ```
 
-Running the test suite should report `46 passed` along with a few warnings:
+Running the test suite should report `47 passed` along with a few warnings:
 
 ```
-46 passed, 24 warnings in 2.0s
+47 passed, 24 warnings in 2.0s
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.

--- a/main.py
+++ b/main.py
@@ -249,9 +249,9 @@ async def load_entry(entry_date: str):
     if file_path.exists():
         async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
             content = await fh.read()
-        # Parse markdown to extract entry text only
-        parts = content.split("# Entry\n", 1)
-        entry_text = parts[1].strip() if len(parts) > 1 else ""
+        # Parse markdown safely to handle different newline styles
+        _, body = split_frontmatter(content)
+        entry_text = parse_entry(body)[1] or body.strip()
         return {"status": "success", "content": entry_text}
     return JSONResponse(status_code=404, content={"status": "not_found", "content": ""})
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -125,6 +125,16 @@ def test_load_entry(test_client):
     assert resp.json()["content"] == "B"
 
 
+def test_load_entry_windows_newlines(test_client):
+    """load_entry handles Windows CRLF line endings."""
+    (main.DATA_DIR / "2020-02-03.md").write_text(
+        "# Prompt\r\nA\r\n\r\n# Entry\r\nB", encoding="utf-8"
+    )
+    resp = test_client.get("/entry", params={"entry_date": "2020-02-03"})
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "B"
+
+
 def test_load_entry_missing(test_client):
     """Loading a missing entry should return 404."""
     resp = test_client.get("/entry", params={"entry_date": "2000-01-01"})
@@ -365,8 +375,7 @@ def test_archive_filter_and_sort(test_client):
         "---\n"
         "# Prompt\nP2\n\n# Entry\nE2"
     )
-    entry3 = (
-        """---
+    entry3 = """---
 location: Atown
 photos: []
 ---
@@ -375,7 +384,6 @@ P3
 
 # Entry
 E3"""
-    )
     (main.DATA_DIR / "2021-07-01.md").write_text(entry1, encoding="utf-8")
     (main.DATA_DIR / "2021-07-02.md").write_text(entry2, encoding="utf-8")
     (main.DATA_DIR / "2021-07-03.md").write_text(entry3, encoding="utf-8")
@@ -440,8 +448,7 @@ def test_archive_current_month_open(test_client):
 
 def test_view_entry_shows_wotd(test_client):
     """Word of the day from frontmatter should appear in view page."""
-    content = (
-        """---
+    content = """---
 wotd: luminous
 photos: []
 ---
@@ -450,7 +457,6 @@ P
 
 # Entry
 E"""
-    )
     (main.DATA_DIR / "2021-08-01.md").write_text(content, encoding="utf-8")
     resp = test_client.get("/archive/2021-08-01")
     assert resp.status_code == 200
@@ -459,8 +465,7 @@ E"""
 
 def test_archive_shows_wotd_icon(test_client):
     """Entries with a word of the day show an icon in the archive."""
-    content = (
-        """---
+    content = """---
 wotd: zephyr
 photos: []
 ---
@@ -469,7 +474,6 @@ P
 
 # Entry
 E"""
-    )
     (main.DATA_DIR / "2021-09-09.md").write_text(content, encoding="utf-8")
     resp = test_client.get("/archive")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- handle Windows CRLF endings when loading entries
- test load_entry with Windows newlines
- update test count in README
- move bug 31 to BUGS_FIXED

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68888e824ac88332a0f4cee452525062