### PR TITLE
Fix save_entry validation error status codes

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -6,14 +6,6 @@ The following issues are still unresolved. Fixed bugs have been moved to [BUGS_F
 
 
 
-33. **Validation errors return HTTP 200**
-   - `save_entry` returns an error object but still uses status code 200 when required fields are missing.
-   - Lines:
-     ```python
-     if not entry_date or not content or not prompt:
-         return {"status": "error", "message": "Missing fields"}
-     ```
-     【F:main.py†L134-L135】
 
 34. **Invalid dates accepted**
    - `save_entry` only sanitizes the filename so strings like `2020-13-40` are saved without complaint.

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -407,5 +407,24 @@ The following issues were identified and subsequently resolved.
      _, body = split_frontmatter(content)
      entry_text = parse_entry(body)[1] or body.strip()
      ```
-     【F:main.py†L250-L255】
+    【F:main.py†L250-L255】
+
+45. **Validation errors return HTTP 200** (fixed)
+   - `save_entry` now returns HTTP 400 when required fields are missing or the
+     provided date is invalid.
+   - Fixed lines:
+     ```python
+     if not entry_date or not content or not prompt:
+         return JSONResponse(
+             status_code=400,
+             content={"status": "error", "message": "Missing fields"},
+         )
+     ...
+     except ValueError:
+         return JSONResponse(
+             status_code=400,
+             content={"status": "error", "message": "Invalid date"},
+         )
+     ```
+     【F:main.py†L183-L198】
 

--- a/main.py
+++ b/main.py
@@ -181,7 +181,10 @@ async def save_entry(data: dict):
     location = data.get("location") or {}
 
     if not entry_date or not content or not prompt:
-        return {"status": "error", "message": "Missing fields"}
+        return JSONResponse(
+            status_code=400,
+            content={"status": "error", "message": "Missing fields"},
+        )
 
     # Ensure /journals exists before attempting to save
     DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -189,7 +192,10 @@ async def save_entry(data: dict):
     try:
         file_path = safe_entry_path(entry_date, DATA_DIR)
     except ValueError:
-        return {"status": "error", "message": "Invalid date"}
+        return JSONResponse(
+            status_code=400,
+            content={"status": "error", "message": "Invalid date"},
+        )
     first_save = not file_path.exists()
     if first_save:
         frontmatter = await build_frontmatter(location)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -105,7 +105,7 @@ def test_word_of_day_in_frontmatter(test_client, monkeypatch):
 def test_save_entry_missing_fields(test_client):
     """Saving with missing required fields should return an error."""
     resp = test_client.post("/entry", json={"date": "2020-01-02"})
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     assert resp.json()["status"] == "error"
 
 


### PR DESCRIPTION
## Summary
- return HTTP 400 when journal entry validation fails
- adjust corresponding test expectation
- move bug note from BUGS.md to BUGS_FIXED.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688890d5738883328295f6c7c92595f9