### PR TITLE
Fix parse_entry header case sensitivity

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -8,17 +8,6 @@ The following issues are still unresolved. Fixed bugs have been moved to [BUGS_F
 
 
 
-37. **Header parsing is case sensitive**
-   - `parse_entry` only recognizes "# Prompt" and "# Entry" exactly; other cases like "# prompt" are ignored.
-   - Lines:
-     ```python
-     if stripped == "# Prompt":
-         current_section = "prompt"
-     if stripped == "# Entry":
-         current_section = "entry"
-     ```
-     【F:main.py†L78-L83】
-
 39. **Prompts cache never invalidates**
    - `load_prompts` stores the prompts in memory forever; changes to `prompts.json` are ignored after startup.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -437,6 +437,20 @@ The following issues were identified and subsequently resolved.
          datetime.strptime(sanitized, "%Y-%m-%d")
      except ValueError as exc:
          raise ValueError("Invalid entry date") from exc
+    ```
+    【F:file_utils.py†L20-L23】
+
+37. **Header parsing is case sensitive** (fixed)
+   - `parse_entry` now matches section headers case-insensitively so variations like `# prompt` are recognized.
+   - Fixed lines:
+     ```python
+     header = stripped.lower()
+     if header == "# prompt":
+         current_section = "prompt"
+         continue
+     if header == "# entry":
+         current_section = "entry"
+         continue
      ```
-     【F:file_utils.py†L20-L23】
+     【F:file_utils.py†L38-L46】
 

--- a/file_utils.py
+++ b/file_utils.py
@@ -37,10 +37,11 @@ def parse_entry(md_content: str) -> Tuple[str, str]:
     current_section = None
     for line in md_content.splitlines():
         stripped = line.strip()
-        if stripped == "# Prompt":
+        header = stripped.lower()
+        if header == "# prompt":
             current_section = "prompt"
             continue
-        if stripped == "# Entry":
+        if header == "# entry":
             current_section = "entry"
             continue
         if current_section == "prompt":


### PR DESCRIPTION
## Summary
- make `parse_entry` accept `# prompt` and `# entry` regardless of case
- move the header parsing bug to BUGS_FIXED.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e8bd291c8332841d471f10c6d842