### PR TITLE
Fix first open bug in BUGS.md

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -8,16 +8,6 @@ The following issues are still unresolved. Fixed bugs have been moved to [BUGS_F
 
 
 
-37. **Header parsing is case sensitive**
-   - `parse_entry` only recognizes "# Prompt" and "# Entry" exactly; other cases like "# prompt" are ignored.
-   - Lines:
-     ```python
-     if stripped == "# Prompt":
-         current_section = "prompt"
-     if stripped == "# Entry":
-         current_section = "entry"
-     ```
-     【F:main.py†L78-L83】
 
 39. **Prompts cache never invalidates**
    - `load_prompts` stores the prompts in memory forever; changes to `prompts.json` are ignored after startup.

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -438,5 +438,18 @@ The following issues were identified and subsequently resolved.
      except ValueError as exc:
          raise ValueError("Invalid entry date") from exc
      ```
-     【F:file_utils.py†L20-L23】
+    【F:file_utils.py†L20-L23】
+
+47. **Header parsing is case sensitive** (fixed)
+   - `parse_entry` now normalizes header lines to lowercase so variations like "# prompt" are recognized.
+   - Fixed lines:
+     ```python
+         stripped = line.strip()
+         lowered = stripped.lower()
+         if lowered == "# prompt":
+             current_section = "prompt"
+         if lowered == "# entry":
+             current_section = "entry"
+     ```
+     【F:file_utils.py†L39-L45】
 

--- a/file_utils.py
+++ b/file_utils.py
@@ -37,10 +37,11 @@ def parse_entry(md_content: str) -> Tuple[str, str]:
     current_section = None
     for line in md_content.splitlines():
         stripped = line.strip()
-        if stripped == "# Prompt":
+        lowered = stripped.lower()
+        if lowered == "# prompt":
             current_section = "prompt"
             continue
-        if stripped == "# Entry":
+        if lowered == "# entry":
             current_section = "entry"
             continue
         if current_section == "prompt":

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -135,6 +135,16 @@ def test_load_entry_windows_newlines(test_client):
     assert resp.json()["content"] == "B"
 
 
+def test_load_entry_case_insensitive_headers(test_client):
+    """load_entry accepts lowercase section headers."""
+    (main.DATA_DIR / "2020-02-04.md").write_text(
+        "# prompt\nA\n\n# entry\nB", encoding="utf-8"
+    )
+    resp = test_client.get("/entry", params={"entry_date": "2020-02-04"})
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "B"
+
+
 def test_load_entry_missing(test_client):
     """Loading a missing entry should return 404."""
     resp = test_client.get("/entry", params={"entry_date": "2000-01-01"})


### PR DESCRIPTION
## Summary
- support case-insensitive headers in `parse_entry`
- add regression test for lower-case headers
- document the fix in `BUGS_FIXED.md`
- remove the entry from `BUGS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888eab15d648332936a8cefb09b318d