### PR TITLE
Fix duplicate save requests bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,24 +1,6 @@
 # Known Bugs
 
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
-
-
-
-
-
-
-
-
-40. **Multiple save clicks send duplicate requests**
-   - The Save button is never disabled during the fetch call, so rapid clicks create several `/entry` POSTs.
-   - Lines:
-     ```javascript
-     saveButton.addEventListener('click', async () => {
-       const response = await fetch("/entry", { ... });
-     });
-     ```
-     【F:templates/echo_journal.html†L161-L174】
-
 41. **Archive view reads entire files into memory**
    - Each entry file is fully loaded even though only a preview is needed, which wastes memory for large archives.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -479,6 +479,20 @@ The following issues were identified and subsequently resolved.
                  except (FileNotFoundError, json.JSONDecodeError):
                      _prompts_cache["data"] = {}
                      _prompts_cache["mtime"] = mtime
+    ```
+    【F:prompt_utils.py†L16-L42】
+
+40. **Multiple save clicks send duplicate requests** (fixed)
+   - The save button is now disabled during the network request to prevent
+     duplicate POSTs when clicked rapidly or triggered via keyboard shortcut.
+   - Fixed lines:
+     ```javascript
+     if (saveButton.disabled) {
+       return;
+     }
+     saveButton.disabled = true;
+     ...
+     saveButton.disabled = false;
      ```
-     【F:prompt_utils.py†L16-L42】
+     【F:templates/echo_journal.html†L163-L216】
 

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -163,6 +163,10 @@ document.addEventListener("DOMContentLoaded", () => {
 const saveButton = document.getElementById('save-button');
 if (saveButton) {
   saveButton.addEventListener('click', async () => {
+    if (saveButton.disabled) {
+      return;
+    }
+    saveButton.disabled = true;
     const content = document.getElementById('journal-text').value;
     const date = "{{ date }}";
     const prompt = {{ prompt | tojson }};
@@ -185,6 +189,7 @@ if (saveButton) {
         if (!response.ok) {
           status.textContent = "Save failed. Server error.";
           status.classList.add('error-text');
+          saveButton.disabled = false;
           return;
         }
 
@@ -200,13 +205,14 @@ if (saveButton) {
         status.textContent = "Save failed. Network error.";
         status.classList.add('error-text');
       }
+      saveButton.disabled = false;
   });
 }
 
 document.addEventListener('keydown', (e) => {
   if ((e.ctrlKey || e.metaKey) && e.key === 's') {
     e.preventDefault();
-    if (saveButton) {
+    if (saveButton && !saveButton.disabled) {
       saveButton.click();
     }
   }


### PR DESCRIPTION
## Summary
- disable save button while a save request is in-flight
- document the fix in BUGS_FIXED
- remove the bug from BUGS list

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f51955388332b356ba52a34638e8