### PR TITLE
Fix archive preview memory usage

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,17 +1,6 @@
 # Known Bugs
 
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
-41. **Archive view reads entire files into memory**
-   - Each entry file is fully loaded even though only a preview is needed, which wastes memory for large archives.
-   - Lines:
-     ```python
-     async with aiofiles.open(file, "r", encoding=ENCODING) as fh:
-         content = await fh.read()
-     entries_by_month[month_key].append((entry_date.isoformat(), content))
-     ```
-     【F:main.py†L263-L272】
-
-
 48. **Templates path not configurable**
    - `Jinja2Templates` is created with a hard-coded `"templates"` directory, ignoring `APP_DIR` or other environment settings.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -494,5 +494,17 @@ The following issues were identified and subsequently resolved.
      ...
      saveButton.disabled = false;
      ```
-     【F:templates/echo_journal.html†L163-L216】
+    【F:templates/echo_journal.html†L163-L216】
+
+41. **Archive view reads entire files into memory** (fixed)
+   - `_collect_entries` used to read each entry file entirely even though only
+     the frontmatter and prompt are needed for the archive preview. The function
+     now reads at most 8192 bytes to avoid loading large files into memory.
+   - Fixed lines:
+     ```python
+         async with aiofiles.open(file, "r", encoding=ENCODING) as fh:
+-            content = await fh.read()
++            content = await fh.read(8192)
+     ```
+     【F:main.py†L301-L304】
 

--- a/main.py
+++ b/main.py
@@ -300,7 +300,7 @@ async def _collect_entries() -> list[dict]:
             continue
         try:
             async with aiofiles.open(file, "r", encoding=ENCODING) as fh:
-                content = await fh.read()
+                content = await fh.read(8192)
         except OSError:
             continue
         frontmatter, body = split_frontmatter(content)


### PR DESCRIPTION
## Summary
- avoid reading entire entry files when building the archive
- document the fix in BUGS_FIXED
- remove the issue from BUGS

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f6fdad4483328f73621bfbd1b225