### PR TITLE
Fix configurable templates path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ DATA_DIR=/journals
 APP_DIR=/app
 PROMPTS_FILE=/app/prompts.json
 STATIC_DIR=/app/static
+TEMPLATES_DIR=/app/templates
 WORDNIK_API_KEY=
 IMMICH_URL=
 IMMICH_API_KEY=

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,13 +1,6 @@
 # Known Bugs
 
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
-48. **Templates path not configurable**
-   - `Jinja2Templates` is created with a hard-coded `"templates"` directory, ignoring `APP_DIR` or other environment settings.
-   - Lines:
-     ```python
-     templates = Jinja2Templates(directory="templates")
-     ```
-     【F:main.py†L53-L54】
 
 49. **Prompt category never saved**
    - Entries are written without storing the selected prompt category, so the information is lost when reloading.

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -505,6 +505,20 @@ The following issues were identified and subsequently resolved.
          async with aiofiles.open(file, "r", encoding=ENCODING) as fh:
 -            content = await fh.read()
 +            content = await fh.read(8192)
+    ```
+    【F:main.py†L301-L304】
+
+48. **Templates path not configurable** (fixed)
+   - `Jinja2Templates` used a hard-coded `"templates"` directory. The
+     path now comes from `TEMPLATES_DIR` so it can be overridden via an
+     environment variable.
+   - Fixed lines:
+     ```python
+     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
      ```
-     【F:main.py†L301-L304】
+     【F:main.py†L101-L102】
+     ```python
+     TEMPLATES_DIR = Path(os.getenv("TEMPLATES_DIR", str(APP_DIR / "templates")))
+     ```
+     【F:config.py†L11-L12】
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The application looks for the following optional variables:
 - `APP_DIR` – base directory for static assets and templates
 - `PROMPTS_FILE` – location of the prompts JSON file
 - `STATIC_DIR` – directory for static files served under `/static`
+- `TEMPLATES_DIR` – directory containing Jinja2 templates
 - `WORDNIK_API_KEY` – API key used to fetch the Wordnik word of the day
 - `IMMICH_URL` – base URL of your Immich API endpoint (for example `http://immich.local/api`)
 - `IMMICH_API_KEY` – API key used to authorize requests to Immich

--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ APP_DIR = Path(os.getenv("APP_DIR", "/app"))
 DATA_DIR = Path(os.getenv("DATA_DIR", "/journals"))
 PROMPTS_FILE = Path(os.getenv("PROMPTS_FILE", str(APP_DIR / "prompts.json")))
 STATIC_DIR = Path(os.getenv("STATIC_DIR", str(APP_DIR / "static")))
+TEMPLATES_DIR = Path(os.getenv("TEMPLATES_DIR", str(APP_DIR / "templates")))
 ENCODING = "utf-8"
 WORDNIK_API_KEY = os.getenv("WORDNIK_API_KEY")
 IMMICH_URL = os.getenv("IMMICH_URL")

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from fastapi.templating import Jinja2Templates
 from config import (
     DATA_DIR,
     STATIC_DIR,
+    TEMPLATES_DIR,
     ENCODING,
     IMMICH_URL,
     IMMICH_API_KEY,
@@ -98,7 +99,7 @@ SAVE_LOCKS = defaultdict(asyncio.Lock)
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 # Setup templates
-templates = Jinja2Templates(directory="templates")
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
 @app.middleware("http")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -25,10 +25,13 @@ STATIC_DIR = APP_DIR / "static"
 PROMPTS_FILE = APP_DIR / "prompts.json"
 DATA_ROOT = Path(tempfile.gettempdir()) / "ej_journals"
 
+TEMPLATES_DIR = ROOT / "templates"
+
 os.environ["APP_DIR"] = str(APP_DIR)
 os.environ["DATA_DIR"] = str(DATA_ROOT)
 os.environ["STATIC_DIR"] = str(STATIC_DIR)
 os.environ["PROMPTS_FILE"] = str(PROMPTS_FILE)
+os.environ["TEMPLATES_DIR"] = str(TEMPLATES_DIR)
 
 # Ensure directories for the application exist before importing ``main``
 STATIC_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add `TEMPLATES_DIR` configuration constant
- load Jinja templates from `TEMPLATES_DIR`
- update tests and docs for new environment variable
- document fix in BUGS_FIXED.md and remove bug from BUGS.md

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fcf7069083329fde368a68b84159