### PR TITLE
Fix saving prompt category

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -2,14 +2,6 @@
 
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
-49. **Prompt category never saved**
-   - Entries are written without storing the selected prompt category, so the information is lost when reloading.
-   - Lines:
-     ```python
-     md_text = f"# Prompt\n{prompt}\n\n# Entry\n{content}"
-     ```
-     【F:main.py†L144-L144】
-
 26. **Deprecated TemplateResponse call order**
    - `templates.TemplateResponse` is still called using the old signature where the template name is first. This triggers a deprecation warning from Starlette.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -518,7 +518,23 @@ The following issues were identified and subsequently resolved.
      ```
      【F:main.py†L101-L102】
      ```python
-     TEMPLATES_DIR = Path(os.getenv("TEMPLATES_DIR", str(APP_DIR / "templates")))
+    TEMPLATES_DIR = Path(os.getenv("TEMPLATES_DIR", str(APP_DIR / "templates")))
+    ```
+    【F:config.py†L11-L12】
+
+49. **Prompt category never saved** (fixed)
+   - Entries were saved without storing the selected prompt category.
+     The save endpoint now persists the category in frontmatter when provided.
+   - Fixed lines:
+     ```python
+     frontmatter = _with_updated_save_time(frontmatter, label)
+     frontmatter = _with_updated_category(frontmatter, category)
      ```
-     【F:config.py†L11-L12】
+     【F:main.py†L224-L227】
+     ```javascript
+     const category = {{ category | tojson }};
+     ...
+     body: JSON.stringify({ date, content, prompt, category, location })
+     ```
+     【F:templates/echo_journal.html†L173-L187】
 

--- a/main.py
+++ b/main.py
@@ -173,12 +173,29 @@ def _with_updated_save_time(frontmatter: str | None, label: str) -> str | None:
     return "\n".join(lines)
 
 
+def _with_updated_category(frontmatter: str | None, category: str | None) -> str | None:
+    """Return frontmatter with the ``category`` value inserted or replaced."""
+    if category is None or category == "":
+        return frontmatter
+    if not frontmatter:
+        return f"category: {category}"
+    lines = frontmatter.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("category:"):
+            lines[i] = f"category: {category}"
+            break
+    else:
+        lines.append(f"category: {category}")
+    return "\n".join(lines)
+
+
 @app.post("/entry")
 async def save_entry(data: dict):
     """Save a journal entry for the provided date."""
     entry_date = data.get("date")
     content = data.get("content")
     prompt = data.get("prompt")
+    category = data.get("category")
     location = data.get("location") or {}
 
     if not entry_date or not content or not prompt:
@@ -206,6 +223,7 @@ async def save_entry(data: dict):
     # Update or add save_time field
     label = time_of_day_label()
     frontmatter = _with_updated_save_time(frontmatter, label)
+    frontmatter = _with_updated_category(frontmatter, category)
 
     md_body = f"# Prompt\n{prompt}\n\n# Entry\n{content}"
     if frontmatter is not None:

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -170,6 +170,7 @@ if (saveButton) {
     const content = document.getElementById('journal-text').value;
     const date = "{{ date }}";
     const prompt = {{ prompt | tojson }};
+    const category = {{ category | tojson }};
     const locEl = document.getElementById('location-display');
     const location = locEl ? {
       lat: parseFloat(locEl.dataset.lat || 0),
@@ -183,7 +184,7 @@ if (saveButton) {
         const response = await fetch("/entry", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ date, content, prompt, location })
+          body: JSON.stringify({ date, content, prompt, category, location })
         });
 
         if (!response.ok) {

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -105,6 +105,20 @@ def test_word_of_day_in_frontmatter(test_client, monkeypatch):
     assert "wotd: serendipity" in text
 
 
+def test_category_saved_in_frontmatter(test_client):
+    """Prompt category should be stored in frontmatter when provided."""
+    payload = {
+        "date": "2020-12-12",
+        "content": "entry",
+        "prompt": "prompt",
+        "category": "Fun",
+    }
+    resp = test_client.post("/entry", json=payload)
+    assert resp.status_code == 200
+    text = (main.DATA_DIR / "2020-12-12.md").read_text(encoding="utf-8")
+    assert "category: Fun" in text
+
+
 def test_save_entry_missing_fields(test_client):
     """Saving with missing required fields should return an error."""
     resp = test_client.post("/entry", json={"date": "2020-01-02"})


### PR DESCRIPTION
## Summary
- persist prompt category in entry frontmatter
- send category from the client when saving
- test that category is saved
- document the fix in BUGS_FIXED and remove from BUGS

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f35d35088332b55616485317a41c