### PR TITLE
Fix deprecated TemplateResponse use

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -2,25 +2,6 @@
 
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
-26. **Deprecated TemplateResponse call order**
-   - `templates.TemplateResponse` is still called using the old signature where the template name is first. This triggers a deprecation warning from Starlette.
-   - Lines:
-     ```python
-     return templates.TemplateResponse(
-         "echo_journal.html",
-         {
-             "request": request,
-             "prompt": prompt,
-             "category": "",
-             "date": date_str,
-             "content": entry,
-             "readonly": False,
-             "active_page": "home",
-         },
-     )
-     ```
-     【F:main.py†L113-L124】
-
 27. **Prompt category never displayed**
    - `generate_prompt` returns a category but the index route ignores it and passes an empty string to the template.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -534,7 +534,29 @@ The following issues were identified and subsequently resolved.
      ```javascript
      const category = {{ category | tojson }};
      ...
-     body: JSON.stringify({ date, content, prompt, category, location })
+    body: JSON.stringify({ date, content, prompt, category, location })
+    ```
+    【F:templates/echo_journal.html†L173-L187】
+
+50. **Deprecated TemplateResponse call order** (fixed)
+   - The index route now calls `TemplateResponse` with the request object first,
+     following the updated Starlette signature.
+   - Fixed lines:
+     ```python
+     return templates.TemplateResponse(
+         request,
+         "echo_journal.html",
+         {
+             "request": request,
+             "prompt": prompt,
+             "category": "",
+             "date": date_str,
+             "content": entry,
+             "readonly": False,
+             "active_page": "home",
+             "wotd": wotd,
+         },
+     )
      ```
-     【F:templates/echo_journal.html†L173-L187】
+     【F:main.py†L147-L160】
 

--- a/main.py
+++ b/main.py
@@ -145,6 +145,7 @@ async def index(request: Request):
         wotd = ""
 
     return templates.TemplateResponse(
+        request,
         "echo_journal.html",
         {
             "request": request,


### PR DESCRIPTION
## Summary
- call `TemplateResponse` with request object first in index route
- move bug note to `BUGS_FIXED.md`
- remove bug from `BUGS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f554b0a48332890285ad8d8cdc76