### PR TITLE
Fix prompt category display

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -2,18 +2,6 @@
 
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
-27. **Prompt category never displayed**
-   - `generate_prompt` returns a category but the index route ignores it and passes an empty string to the template.
-   - Lines:
-     ```python
-     prompt_data = await generate_prompt()
-     prompt = prompt_data["prompt"]
-     ...
-     "category": "",
-     ```
-     【F:main.py†L109-L118】
-
-
 32. **Other routes still use deprecated TemplateResponse signature**
    - `archive_view`, `view_entry`, and `settings_page` pass the template name first instead of the request.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -558,5 +558,21 @@ The following issues were identified and subsequently resolved.
          },
      )
      ```
-     【F:main.py†L147-L160】
+    【F:main.py†L147-L160】
+
+51. **Prompt category never displayed** (fixed)
+   - `generate_prompt` returns a category, but the index route ignored it and
+     sent an empty string to the template. The route now passes the real
+     category and reads it from saved entries.
+   - Fixed lines:
+     ```python
+         prompt_data = await generate_prompt()
+         prompt = prompt_data["prompt"]
+         category = prompt_data.get("category", "")
+     ```
+     ```python
+         category = meta.get("category", "")
+         wotd = meta.get("wotd", "")
+     ```
+     【F:main.py†L138-L155】
 

--- a/main.py
+++ b/main.py
@@ -137,10 +137,12 @@ async def index(request: Request):
         prompt, entry = parse_entry(body)
         if not prompt and not entry:
             entry = body.strip()
+        category = meta.get("category", "")
         wotd = meta.get("wotd", "")
     else:
         prompt_data = await generate_prompt()
         prompt = prompt_data["prompt"]
+        category = prompt_data.get("category", "")
         entry = ""
         wotd = ""
 
@@ -150,7 +152,7 @@ async def index(request: Request):
         {
             "request": request,
             "prompt": prompt,
-            "category": "",  # Optionally store saved category or leave blank for saved entries
+            "category": category,
             "date": date_str,
             "content": entry,
             "readonly": False,  # Explicit


### PR DESCRIPTION
## Summary
- show prompt category on the index page
- document bug fix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f6edb2ac8332b005b5f92f4c06ab