### PR TITLE
Fix template response order

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -2,38 +2,6 @@
 
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
-32. **Other routes still use deprecated TemplateResponse signature**
-   - `archive_view`, `view_entry`, and `settings_page` pass the template name first instead of the request.
-   - Lines:
-     ```python
-     return templates.TemplateResponse(
-         "archives.html",
-         {
-             "request": request,
-             "entries": sorted_entries,
-             "active_page": "archive",
-         },
-     )
-     ...
-     return templates.TemplateResponse(
-         "echo_journal.html",
-         {
-             "request": request,
-             "content": entry,
-             "content_html": html_entry,
-             "date": entry_date,
-             "prompt": prompt,
-             "readonly": True,
-             "active_page": "archive",
-         },
-     )
-     ...
-     return templates.TemplateResponse(
-         "settings.html",
-         {"request": request, "active_page": "settings"},
-     )
-     ```
-     【F:main.py†L277-L327】
 
 35. **Prompt category never rendered**
    - The journal template lacks any element to show the `category` variable.

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -574,5 +574,25 @@ The following issues were identified and subsequently resolved.
          category = meta.get("category", "")
          wotd = meta.get("wotd", "")
      ```
-     【F:main.py†L138-L155】
+    【F:main.py†L138-L155】
+
+52. **Other routes used deprecated TemplateResponse call order** (fixed)
+   - `archive_view`, `archive_entry`, and `settings_page` now pass the
+     request object as the first argument to `TemplateResponse`.
+   - Fixed lines:
+     ```python
+     return templates.TemplateResponse(
+         request,
+         "archives.html",
+         {
+             "request": request,
+             "entries": sorted_entries,
+             "active_page": "archive",
+             "sort_by": sort_by,
+             "filter_val": filter_,
+             "current_month": current_month,
+         },
+     )
+     ```
+     【F:main.py†L379-L389】
 

--- a/main.py
+++ b/main.py
@@ -377,6 +377,7 @@ async def archive_view(
     current_month = datetime.now().strftime("%Y-%m")
 
     return templates.TemplateResponse(
+        request,
         "archives.html",
         {
             "request": request,
@@ -418,6 +419,7 @@ async def archive_entry(request: Request, entry_date: str):
     songs = await load_json_file(file_path.with_suffix(".songs.json"))
 
     return templates.TemplateResponse(
+        request,
         "archive-entry.html",
         {
             "request": request,
@@ -444,6 +446,7 @@ async def archive_entry(request: Request, entry_date: str):
 async def settings_page(request: Request):
     """Render the user settings page."""
     return templates.TemplateResponse(
+        request,
         "settings.html",
         {"request": request, "active_page": "settings"},
     )


### PR DESCRIPTION
## Summary
- fix deprecated `TemplateResponse` call order in archive and settings routes
- document the fix in `BUGS_FIXED.md`
- remove resolved issue from `BUGS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f8779dc08332b49967fdfcabbba1