### PR TITLE
Fix category display

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,13 +3,6 @@
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
 
-35. **Prompt category never rendered**
-   - The journal template lacks any element to show the `category` variable.
-   - Lines:
-     ```html
-     <p id="daily-prompt" class="font-sans font-medium ...">{{ prompt }}</p>
-     ```
-     【F:templates/echo_journal.html†L18-L21】
 
 36. **Trailing newlines stripped from entries**
    - `parse_entry` removes final blank lines when assembling the prompt and entry sections.

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -594,5 +594,15 @@ The following issues were identified and subsequently resolved.
          },
      )
      ```
-     【F:main.py†L379-L389】
+    【F:main.py†L379-L389】
+
+53. **Prompt category never rendered** (fixed)
+   - The journal page now shows the prompt's category beneath the prompt text.
+   - Fixed lines:
+     ```html
+     {% if category %}
+     <p id="prompt-category" class="text-sm italic text-gray-600 dark:text-gray-400 mb-1">{{ category }}</p>
+     {% endif %}
+     ```
+     【F:templates/echo_journal.html†L20-L22】
 

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -17,6 +17,9 @@
 <section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
   <div class="p-4 border-b border-gray-300 dark:border-gray-600 mb-6">
     <p id="daily-prompt" class="font-sans font-medium text-[clamp(1.5rem,2vw+1rem,2rem)] leading-snug mb-2 opacity-0">{{ prompt }}</p>
+    {% if category %}
+    <p id="prompt-category" class="text-sm italic text-gray-600 dark:text-gray-400 mb-1">{{ category }}</p>
+    {% endif %}
     <p class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- show the prompt's category in the entry page
- move resolved bug from BUGS.md to BUGS_FIXED.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b338ad2808332ac286e5975c54588