### PR TITLE
Fix parse_entry newline stripping bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,18 +3,6 @@
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
 
-
-36. **Trailing newlines stripped from entries**
-   - `parse_entry` removes final blank lines when assembling the prompt and entry sections.
-   - Lines:
-     ```python
-     prompt = "\n".join(prompt_lines).strip()
-     entry  = "\n".join(entry_lines).strip()
-     ```
-     【F:main.py†L90-L91】
-
-
-
 51. **Malformed filenames hidden from archive**
    - Files with names that don't parse as dates are silently skipped, so they never appear in the archive view.
    - Lines:

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -606,3 +606,12 @@ The following issues were identified and subsequently resolved.
      ```
      【F:templates/echo_journal.html†L20-L22】
 
+
+36. **Trailing newlines stripped from entries** (fixed)
+   - `parse_entry` removed final blank lines when assembling the prompt and entry sections.
+   - Fixed lines:
+     ```python
+     prompt = "\n".join(prompt_lines)
+     entry = "\n".join(entry_lines)
+     ```
+     【F:file_utils.py†L52-L53】

--- a/file_utils.py
+++ b/file_utils.py
@@ -49,8 +49,8 @@ def parse_entry(md_content: str) -> Tuple[str, str]:
         elif current_section == "entry":
             entry_lines.append(line.rstrip())
 
-    prompt = "\n".join(prompt_lines).strip()
-    entry = "\n".join(entry_lines).strip()
+    prompt = "\n".join(prompt_lines)
+    entry = "\n".join(entry_lines)
     return prompt, entry
 
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,9 @@
+import file_utils
+
+
+def test_parse_entry_preserves_trailing_newlines():
+    md = "# Prompt\nP\n\n# Entry\nLine\n\n"
+    prompt, entry = file_utils.parse_entry(md)
+    assert prompt == "P\n"
+    assert entry == "Line\n"
+


### PR DESCRIPTION
## Summary
- keep trailing blank lines when parsing entries
- add regression test for `parse_entry`
- move bug record to BUGS_FIXED

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b369ab0f08332b243e9f937d2c829