### PR TITLE
Fix save_time frontmatter handling

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,17 +3,6 @@
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
 
-53. **save_time duplication with indented frontmatter**
-   - `_with_updated_save_time` only matches lines starting exactly with
-     `"save_time:"`, so entries with indented keys get a second `save_time`
-     line appended.
-   - Lines:
-     ```python
-     if line.startswith("save_time:"):
-         lines[i] = f"save_time: {label}"
-     ```
-     【F:main.py†L166-L172】
-
 54. **Duplicate dates inflate streak counts**
    - `_calculate_streaks` iterates each entry file without deduplicating dates,
      so multiple files for the same day extend streaks incorrectly.

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -699,5 +699,18 @@ The following issues were identified and subsequently resolved.
      except (httpx.HTTPError, ValueError) as exc:
          raise HTTPException(status_code=502, detail="Reverse geocoding failed") from exc
      ```
-     【F:main.py†L596-L602】
+    【F:main.py†L596-L602】
+
+58. **save_time duplication with indented frontmatter** (fixed)
+   - `_with_updated_save_time` now matches and replaces a `save_time` key even
+     when it is indented. This prevents multiple `save_time` lines from being
+     appended.
+   - Fixed lines:
+     ```python
+     stripped = line.lstrip()
+     if stripped.startswith("save_time:"):
+         indent = line[: len(line) - len(stripped)]
+         lines[i] = f"{indent}save_time: {label}"
+     ```
+     【F:main.py†L169-L175】
 

--- a/main.py
+++ b/main.py
@@ -168,8 +168,10 @@ def _with_updated_save_time(frontmatter: str | None, label: str) -> str | None:
         return f"save_time: {label}"
     lines = frontmatter.splitlines()
     for i, line in enumerate(lines):
-        if line.startswith("save_time:"):
-            lines[i] = f"save_time: {label}"
+        stripped = line.lstrip()
+        if stripped.startswith("save_time:"):
+            indent = line[: len(line) - len(stripped)]
+            lines[i] = f"{indent}save_time: {label}"
             break
     else:
         lines.append(f"save_time: {label}")

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -1,0 +1,12 @@
+import main
+
+
+def test_with_updated_save_time_replaces_indented():
+    """Existing save_time with indentation should be replaced, not duplicated."""
+    fm = "  save_time: Morning\nother: x"
+    updated = main._with_updated_save_time(fm, "Evening")
+    lines = updated.splitlines()
+    assert lines[0] == "  save_time: Evening"
+    assert lines[1] == "other: x"
+    assert updated.count("save_time:") == 1
+


### PR DESCRIPTION
## Summary
- handle indentation when updating `save_time`
- add regression test for `_with_updated_save_time`
- remove solved bug from BUGS.md
- document the fix in BUGS_FIXED.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4b31f19c83328b5c97d1e127ac28