### PR TITLE
Fix pylint warnings in tests

### DIFF
--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,9 +1,11 @@
+"""Tests for file utilities."""
+
 import file_utils
 
 
 def test_parse_entry_preserves_trailing_newlines():
+    """``parse_entry`` should keep trailing newlines in the entry."""
     md = "# Prompt\nP\n\n# Entry\nLine\n\n"
     prompt, entry = file_utils.parse_entry(md)
     assert prompt == "P\n"
     assert entry == "Line\n"
-

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -1,3 +1,7 @@
+"""Tests for helper functions in ``main``."""
+
+# pylint: disable=protected-access
+
 import main
 
 
@@ -9,4 +13,3 @@ def test_with_updated_save_time_replaces_indented():
     assert lines[0] == "  save_time: Evening"
     assert lines[1] == "other: x"
     assert updated.count("save_time:") == 1
-


### PR DESCRIPTION
## Summary
- clean up test helper to avoid lambda and add documentation
- add module and function docstrings in tests
- disable pylint protected-access warning where necessary

## Testing
- `black tests/test_endpoints.py tests/test_file_utils.py tests/test_main_utils.py`
- `PYTHONPATH=. pylint tests/test_endpoints.py tests/test_file_utils.py tests/test_main_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4ce5ebc883328d2318fdeba85027