### PR TITLE
Add YAML frontmatter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,27 @@
 - Markdown format for longevity and openness  
 - Support single-action journaling: open → type → save  
 - Clear UI/API separation using FastAPI + Jinja2
+
+## YAML Frontmatter Structure
+
+Each journal entry begins with a YAML frontmatter block. The application uses this metadata when rendering pages.
+
+```yaml
+location: Example Place
+weather: 18°C code 1
+save_time: Evening
+wotd: luminous
+category: Gratitude
+photos: []
+```
+
+**Field descriptions**
+
+- `location` – text label of your current location when saving.
+- `weather` – raw weather string from the API used by `format_weather`.
+- `save_time` – time of day label (Morning/Afternoon/Evening/Night).
+- `wotd` – Wordnik "word of the day" if available.
+- `category` – prompt category chosen when saving.
+- `photos` – placeholder list updated when photos are linked.
+
+Additional keys may be added as new enrichment features are implemented.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@
   - Optional secure remote access (auth, VPN/reverse proxy).
 
 ## Phase 5: Enrichment and polish (in progress)
-- Document YAML frontmatter structure in the README
+- Document YAML frontmatter structure in the README ✅ Completed
 - Add optional "Fact of the Day" integration
 - Provide an AI-assisted prompt helper
 - Allow refreshing the prompt via a "New Prompt" link


### PR DESCRIPTION
## Summary
- document YAML frontmatter format in README
- mark frontmatter documentation task as completed in ROADMAP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c832bfcd083328dc7ff08ee666ea0