### PR TITLE
Fix streak counts for duplicate dates

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,14 +3,3 @@
 The following issues are still unresolved. Fixed bugs have been moved to [BUGS_FIXED.md](BUGS_FIXED.md).
 
 
-54. **Duplicate dates inflate streak counts**
-   - `_calculate_streaks` iterates each entry file without deduplicating dates,
-     so multiple files for the same day extend streaks incorrectly.
-   - Lines:
-     ```python
-     for d in entry_dates:
-         if prev and d == prev + timedelta(days=1):
-             current_day_streak += 1
-     ```
-     【F:main.py†L430-L435】
-

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -707,10 +707,24 @@ The following issues were identified and subsequently resolved.
      appended.
    - Fixed lines:
      ```python
-     stripped = line.lstrip()
-     if stripped.startswith("save_time:"):
-         indent = line[: len(line) - len(stripped)]
-         lines[i] = f"{indent}save_time: {label}"
+    stripped = line.lstrip()
+    if stripped.startswith("save_time:"):
+        indent = line[: len(line) - len(stripped)]
+        lines[i] = f"{indent}save_time: {label}"
+    ```
+    【F:main.py†L169-L175】
+
+59. **Duplicate dates inflate streak counts** (fixed)
+   - `_calculate_streaks` now deduplicates dates before computing streaks so
+     multiple files for the same day no longer affect the counts.
+   - Fixed lines:
+     ```python
+     unique_dates = sorted(set(entry_dates))
+     for d in unique_dates:
+         if prev and d == prev + timedelta(days=1):
+             current_day_streak += 1
+         else:
+             current_day_streak = 1 if unique_dates else 0
      ```
-     【F:main.py†L169-L175】
+     【F:main.py†L521-L531】
 

--- a/main.py
+++ b/main.py
@@ -518,25 +518,25 @@ async def _gather_entry_stats() -> tuple[dict, int, int, list[date]]:
 
 def _calculate_streaks(entry_dates: list[date]) -> dict[str, int]:
     """Return current and longest day/week streaks."""
-    entry_dates.sort()
+    unique_dates = sorted(set(entry_dates))
     current_day_streak = 0
     longest_day_streak = 0
     prev = None
-    for d in entry_dates:
+    for d in unique_dates:
         if prev and d == prev + timedelta(days=1):
             current_day_streak += 1
         else:
-            current_day_streak = 1 if entry_dates else 0
+            current_day_streak = 1 if unique_dates else 0
         longest_day_streak = max(longest_day_streak, current_day_streak)
         prev = d
 
-    if not entry_dates:
+    if not unique_dates:
         current_day_streak = longest_day_streak = 0
 
     week_starts = sorted(
         {
             date.fromisocalendar(d.isocalendar()[0], d.isocalendar()[1], 1)
-            for d in entry_dates
+            for d in unique_dates
         }
     )
     current_week_streak = 0

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -2,6 +2,9 @@
 
 # pylint: disable=protected-access
 
+from datetime import date
+import importlib
+
 import main
 
 
@@ -13,3 +16,33 @@ def test_with_updated_save_time_replaces_indented():
     assert lines[0] == "  save_time: Evening"
     assert lines[1] == "other: x"
     assert updated.count("save_time:") == 1
+
+
+def test_calculate_streaks_deduplicates_dates(tmp_path, monkeypatch):
+    """Duplicate entry dates should not inflate streak counts."""
+
+    monkeypatch.setenv("APP_DIR", str(tmp_path))
+    (tmp_path / "static").mkdir()
+    monkeypatch.setenv("STATIC_DIR", str(tmp_path / "static"))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("TEMPLATES_DIR", str(tmp_path))
+    monkeypatch.setenv("PROMPTS_FILE", str(tmp_path / "prompts.json"))
+
+    mod = importlib.reload(main)
+
+    dates = [
+        date(2022, 1, 1),
+        date(2022, 1, 1),
+        date(2022, 1, 2),
+        date(2022, 1, 3),
+        date(2022, 1, 3),
+    ]
+
+    streaks = mod._calculate_streaks(dates)
+
+    assert streaks == {
+        "current_day_streak": 3,
+        "longest_day_streak": 3,
+        "current_week_streak": 2,
+        "longest_week_streak": 2,
+    }


### PR DESCRIPTION
## Summary
- deduplicate dates before calculating streaks
- test streak calculations with duplicate dates
- document bug fix in BUGS_FIXED
- remove resolved bug from BUGS.md

## Testing
- `APP_DIR=$(pwd) DATA_DIR=$(pwd)/journals STATIC_DIR=$(pwd)/static TEMPLATES_DIR=$(pwd)/templates PROMPTS_FILE=$(pwd)/prompts.json pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c84d061688332a28f796c4409f2c4