### PR TITLE
Use PyYAML for frontmatter parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ This builds the CSS and starts the app on <http://localhost:8510>.
 
    ```bash
    pip install -r requirements.txt
+   # requirements.txt installs PyYAML for YAML frontmatter parsing
    npm install
    npm run build:css
    ```

--- a/file_utils.py
+++ b/file_utils.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime
 
 import aiofiles
+import yaml
 
 from config import DATA_DIR, ENCODING
 
@@ -76,15 +77,15 @@ async def read_existing_frontmatter(file_path: Path) -> Optional[str]:
         return None
 
 
-def parse_frontmatter(frontmatter: str) -> Dict[str, str]:
-    """Return a dict of key/value pairs from a simple YAML frontmatter string."""
-    result: Dict[str, str] = {}
-    for line in frontmatter.splitlines():
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        result[key.strip()] = value.strip()
-    return result
+def parse_frontmatter(frontmatter: str) -> Dict[str, Any]:
+    """Return a dictionary parsed from YAML frontmatter."""
+    try:
+        data = yaml.safe_load(frontmatter) or {}
+    except yaml.YAMLError:
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
 
 
 async def load_json_file(file_path: Path) -> List[Dict[str, Any]]:

--- a/main.py
+++ b/main.py
@@ -288,7 +288,7 @@ async def load_entry(entry_date: str):
 
 async def _load_extra_meta(md_file: Path, meta: dict) -> None:
     """Populate ``meta`` with photo and song info if present."""
-    if meta.get("photos") in (None, "[]"):
+    if meta.get("photos") in (None, [], "[]"):
         json_path = md_file.with_suffix(".photos.json")
         if json_path.exists():
             try:
@@ -356,7 +356,9 @@ async def archive_view(
         all_entries = [e for e in all_entries if e["meta"].get("weather")]
     elif filter_ == "has_photos":
         all_entries = [
-            e for e in all_entries if e["meta"].get("photos") not in (None, "[]")
+            e
+            for e in all_entries
+            if e["meta"].get("photos") not in (None, "[]", [])
         ]
     elif filter_ == "has_songs":
         all_entries = [e for e in all_entries if e["meta"].get("songs")]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiofiles
 markdown
 bleach
 httpx
+pyyaml

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -9,3 +9,25 @@ def test_parse_entry_preserves_trailing_newlines():
     prompt, entry = file_utils.parse_entry(md)
     assert prompt == "P\n"
     assert entry == "Line\n"
+
+
+def test_parse_frontmatter_simple_pairs():
+    """Simple key/value YAML should be parsed into a dictionary."""
+    fm = "location: Testville\nweather: Warm"
+    meta = file_utils.parse_frontmatter(fm)
+    assert meta["location"] == "Testville"
+    assert meta["weather"] == "Warm"
+
+
+def test_parse_frontmatter_list_values():
+    """YAML lists should be returned as Python lists."""
+    fm = "photos:\n  - img1.jpg\n  - img2.jpg\n"
+    meta = file_utils.parse_frontmatter(fm)
+    assert meta["photos"] == ["img1.jpg", "img2.jpg"]
+
+
+def test_parse_frontmatter_invalid_returns_empty():
+    """Malformed YAML should result in an empty dict."""
+    fm = "bad: [unclosed"
+    meta = file_utils.parse_frontmatter(fm)
+    assert meta == {}


### PR DESCRIPTION
## Summary
- add `pyyaml` dependency
- document `pyyaml` in setup instructions
- parse frontmatter using `yaml.safe_load`
- adjust photo metadata checks for new types
- test YAML frontmatter parsing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9a5c56ec83329b43c7239e0abb7c