### PR TITLE
Add Jellyfin media history

### DIFF
--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -36,6 +36,16 @@
           {% endfor %}
         </ul>
       </details>
+      <details id="media-display" class="text-xs text-gray-600 dark:text-gray-300 mt-3 {% if not media %}hidden{% endif %}">
+        <summary class="cursor-pointer font-medium">🎬 Watched</summary>
+        <ul class="list-disc list-inside pl-4 mt-1">
+          {% for m in media %}
+          <li>
+            {% if m.series %}{{ m.series }} - {{ m.title }}{% else %}{{ m.title }}{% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+      </details>
     </div>
   </details>
 

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -21,6 +21,7 @@
       <option value="weather" {% if sort_by == 'weather' %}selected{% endif %}>Weather</option>
       <option value="photos" {% if sort_by == 'photos' %}selected{% endif %}>Photos</option>
       <option value="songs" {% if sort_by == 'songs' %}selected{% endif %}>Songs</option>
+      <option value="media" {% if sort_by == 'media' %}selected{% endif %}>Media</option>
     </select>
   </label>
   <label>Filter
@@ -30,6 +31,7 @@
       <option value="has_weather" {% if filter_val == 'has_weather' %}selected{% endif %}>Has weather</option>
       <option value="has_photos" {% if filter_val == 'has_photos' %}selected{% endif %}>Has photos</option>
       <option value="has_songs" {% if filter_val == 'has_songs' %}selected{% endif %}>Has songs</option>
+      <option value="has_media" {% if filter_val == 'has_media' %}selected{% endif %}>Has movies/TV</option>
     </select>
   </label>
 </form>
@@ -48,6 +50,7 @@
               {% if meta.weather %}<span title="Weather">☁️</span>{% endif %}
               {% if meta.photos and meta.photos != '[]' %}<span title="Photos">📸</span>{% endif %}
               {% if meta.songs %}<span title="Songs">🎵</span>{% endif %}
+              {% if meta.media %}<span title="Movies/TV">🎬</span>{% endif %}
               {% if meta.wotd %}<span title="Word of the day">📖</span>{% endif %}
             </div>
           </a>


### PR DESCRIPTION
## Summary
- fetch Jellyfin movies/TV for a date and save to `.media.json`
- expose new metadata when saving and viewing entries
- show a 🎬 icon in the archive and add filter option
- support media metadata in entry archive views
- test fetch logic and file creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ca22b8c5c83329115a8d037d6d0e3