### PR TITLE
Fix spacing above journal textarea

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 <section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
-  <div class="p-4 border-b border-gray-300 dark:border-gray-600 mb-6">
+  <div class="p-4 border-b border-gray-300 dark:border-gray-600 mb-2">
     <p id="daily-prompt" class="font-sans font-medium text-[clamp(1.5rem,2vw+1rem,2rem)] leading-snug mb-2 opacity-0">{{ prompt }}</p>
     {% if category %}
     <p id="prompt-category" class="text-sm italic text-gray-600 dark:text-gray-400 mb-1">{{ category }}</p>


### PR DESCRIPTION
## Summary
- reduce margin below the prompt section so the textarea is closer to the top

## Checklist
- [x] Tests pass (`pytest`)
- [x] Code is formatted with `black` and linted with `pylint`
- [x] Documentation updated if needed

------
https://chatgpt.com/codex/tasks/task_e_688d266a34a88332aad6cad5b0d8b4a1