### PR TITLE
Move mood selector under editor

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -24,24 +24,6 @@
     {% endif %}
     <a href="#" id="new-prompt" class="text-xs text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">New Prompt</a>
     <p class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
-    <div id="mood-energy" class="mt-4 flex flex-wrap justify-center gap-4">
-      <label for="mood-select" class="sr-only">Mood</label>
-      <select id="mood-select" class="border rounded px-2 py-1 text-sm">
-        <option value="">Mood</option>
-        <option value="sad">😔 Sad</option>
-        <option value="meh">😐 Meh</option>
-        <option value="okay">😊 Okay</option>
-        <option value="joyful">😍 Joyful</option>
-      </select>
-      <label for="energy-select" class="sr-only">Energy</label>
-      <select id="energy-select" class="border rounded px-2 py-1 text-sm">
-        <option value="">Energy</option>
-        <option value="drained">🪫 Drained</option>
-        <option value="low">😴 Low</option>
-        <option value="ok">🙂 OK</option>
-        <option value="energized">⚡ Energized</option>
-      </select>
-    </div>
   </div>
 </section>
 <section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">
@@ -57,6 +39,24 @@
     oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
     rows="4">{{ content }}</textarea>
 </section>
+<div id="mood-energy" class="mt-4 flex flex-wrap justify-center gap-4">
+  <label for="mood-select" class="sr-only">Mood</label>
+  <select id="mood-select" class="border rounded px-2 py-1 text-sm">
+    <option value="">Mood</option>
+    <option value="sad">😔 Sad</option>
+    <option value="meh">😐 Meh</option>
+    <option value="okay">😊 Okay</option>
+    <option value="joyful">😍 Joyful</option>
+  </select>
+  <label for="energy-select" class="sr-only">Energy</label>
+  <select id="energy-select" class="border rounded px-2 py-1 text-sm">
+    <option value="">Energy</option>
+    <option value="drained">🪫 Drained</option>
+    <option value="low">😴 Low</option>
+    <option value="ok">🙂 OK</option>
+    <option value="energized">⚡ Energized</option>
+  </select>
+</div>
   <section class="w-full mx-auto mt-6 p-4 rounded-xl">
     <button id="save-button" class="block w-[65%] max-w-[15rem] mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>


### PR DESCRIPTION
## Summary
- move mood/energy controls out of prompt block
- place them below the journal editor before the save button

## Checklist
- [x] Tests pass (`pytest -q`)
- [x] Code is formatted with `black` and linted with `pylint`
- [ ] Documentation updated if needed

------
https://chatgpt.com/codex/tasks/task_e_688d2f022ae483328143e0c2c73d534e