### PR TITLE
Adjust prompt header sizing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -234,11 +234,16 @@ summary::-webkit-details-marker {
 
 /* Emphasize journaling flow */
 .welcome-message {
-  font-size: clamp(1rem, 1vw + 0.75rem, 1.5rem);
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.5rem);
   font-weight: 700;
 }
 
 #daily-prompt {
-  font-size: clamp(1.4rem, 2.5vw + 1rem, 2.25rem);
+  font-size: clamp(1.75rem, 3vw + 1.2rem, 2.75rem);
   font-weight: 600;
+}
+
+#prompt-category,
+#intro-tagline {
+  font-size: clamp(0.75rem, 0.6vw + 0.6rem, 0.875rem);
 }

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -15,15 +15,17 @@
 
 {% block content %}
 <section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
-  <div class="p-4 border-b border-gray-300 dark:border-gray-600 mb-2">
-    <p id="daily-prompt" class="font-sans leading-snug mb-2 opacity-0">{{ prompt }}</p>
+  <div class="p-4 border-b border-gray-300 dark:border-gray-600 mb-2 space-y-1">
+    <div class="flex items-center justify-center gap-2">
+      <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
+      <a href="#" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-lg" aria-label="New Prompt">🔄</a>
+    </div>
     {% if category %}
-    <p id="prompt-category" class="text-sm italic text-gray-600 dark:text-gray-400 mb-1">{{ category }}</p>
+    <p id="prompt-category" class="italic text-gray-600 dark:text-gray-400">{{ category }}</p>
     {% else %}
-    <p id="prompt-category" class="text-sm italic text-gray-600 dark:text-gray-400 mb-1 hidden"></p>
+    <p id="prompt-category" class="italic text-gray-600 dark:text-gray-400 hidden"></p>
     {% endif %}
-    <a href="#" id="new-prompt" class="text-xs text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline">New Prompt</a>
-    <p class="text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
+    <p id="intro-tagline" class="text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
   </div>
 </section>
 <section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">


### PR DESCRIPTION
## Summary
- enlarge welcome text and prompt
- shrink category and tagline
- swap "New Prompt" text with refresh icon and move inline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d44d5f9408332ab87c7c0ea38e710