### PR TITLE
Fix toolbar accessibility labels

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -29,11 +29,11 @@
   </div>
 </section>
 <section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">
-  <div id="md-toolbar" class="space-x-2 justify-center markdown-toolbar" aria-label="Formatting toolbar">
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="bold" title="Bold"><strong>B</strong></button>
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="italic" title="Italic"><em>I</em></button>
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="header" title="Heading">H1</button>
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="list" title="List">&#8226;</button>
+  <div id="md-toolbar" class="space-x-2 justify-center markdown-toolbar" aria-label="Formatting toolbar" role="toolbar">
+    <button type="button" class="md-btn text-base md:text-2xl" data-action="bold" title="Bold" aria-label="Bold"><strong>B</strong></button>
+    <button type="button" class="md-btn text-base md:text-2xl" data-action="italic" title="Italic" aria-label="Italic"><em>I</em></button>
+    <button type="button" class="md-btn text-base md:text-2xl" data-action="header" title="Heading" aria-label="Heading">H1</button>
+    <button type="button" class="md-btn text-base md:text-2xl" data-action="list" title="List" aria-label="List">&#8226;</button>
   </div>
   <label for="journal-text" class="sr-only">Journal entry</label>
   <textarea id="journal-text" class="journal-textarea"


### PR DESCRIPTION
## Summary
- add `role="toolbar"` to the markdown toolbar
- provide `aria-label`s for formatting buttons

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d4bd1bbc883329a941a37fde784b6