### PR TITLE
Wrap selects in mood/energy fieldset

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -41,7 +41,8 @@
     oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
     rows="4">{{ content }}</textarea>
 </section>
-<div id="mood-energy" class="mt-4 flex flex-wrap justify-center gap-4">
+<fieldset id="mood-energy" class="mt-4 flex flex-wrap justify-center gap-4 border-0 m-0 p-0">
+  <legend class="sr-only">Mood and energy (optional)</legend>
   <label for="mood-select" class="sr-only">Mood</label>
   <select id="mood-select" class="border rounded px-2 py-1 text-sm">
     <option value="">Mood</option>
@@ -58,7 +59,7 @@
     <option value="ok">🙂 OK</option>
     <option value="energized">⚡ Energized</option>
   </select>
-</div>
+</fieldset>
   <section class="w-full mx-auto mt-6 p-4 rounded-xl">
     <button id="save-button" class="block w-full max-w-sm mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>


### PR DESCRIPTION
## Summary
- wrap mood/energy selectors in a `<fieldset>` with a legend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d504e089c833287b9b77019ef56f3