### PR TITLE
Wrap mood & energy fields in details

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -41,25 +41,28 @@
     oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
     rows="4">{{ content }}</textarea>
 </section>
-<fieldset id="mood-energy" class="mt-4 flex flex-wrap justify-center gap-4 border-0 m-0 p-0">
-  <legend class="sr-only">Mood and energy (optional)</legend>
-  <label for="mood-select" class="sr-only">Mood</label>
-  <select id="mood-select" class="border rounded px-2 py-1 text-sm">
-    <option value="">Mood</option>
-    <option value="sad">😔 Sad</option>
-    <option value="meh">😐 Meh</option>
-    <option value="okay">😊 Okay</option>
-    <option value="joyful">😍 Joyful</option>
-  </select>
-  <label for="energy-select" class="sr-only">Energy</label>
-  <select id="energy-select" class="border rounded px-2 py-1 text-sm">
-    <option value="">Energy</option>
-    <option value="drained">🪫 Drained</option>
-    <option value="low">😴 Low</option>
-    <option value="ok">🙂 OK</option>
-    <option value="energized">⚡ Energized</option>
-  </select>
-</fieldset>
+<details id="mood-energy-details" class="mt-4 w-full">
+  <summary class="cursor-pointer text-center font-semibold">Mood &amp; Energy (optional)</summary>
+  <fieldset id="mood-energy" class="mt-2 flex flex-wrap justify-center gap-4 border-0 m-0 p-0">
+    <legend class="sr-only">Mood and energy (optional)</legend>
+    <label for="mood-select" class="sr-only">Mood</label>
+    <select id="mood-select" class="border rounded px-2 py-1 text-sm">
+      <option value="">Mood</option>
+      <option value="sad">😔 Sad</option>
+      <option value="meh">😐 Meh</option>
+      <option value="okay">😊 Okay</option>
+      <option value="joyful">😍 Joyful</option>
+    </select>
+    <label for="energy-select" class="sr-only">Energy</label>
+    <select id="energy-select" class="border rounded px-2 py-1 text-sm">
+      <option value="">Energy</option>
+      <option value="drained">🪫 Drained</option>
+      <option value="low">😴 Low</option>
+      <option value="ok">🙂 OK</option>
+      <option value="energized">⚡ Energized</option>
+    </select>
+  </fieldset>
+</details>
   <section class="w-full mx-auto mt-6 p-4 rounded-xl">
     <button id="save-button" class="block w-full max-w-sm mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>


### PR DESCRIPTION
## Summary
- hide mood & energy dropdowns in a collapsible `<details>` section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d56c6270c8332977892a616d28939