### PR TITLE
Make optional prompt meta collapsible

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -20,12 +20,15 @@
       <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
       <button type="button" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-lg" aria-label="New Prompt">Refresh prompt</button>
     </div>
-    {% if category %}
-    <p id="prompt-category" class="italic text-gray-600 dark:text-gray-400">{{ category }}</p>
-    {% else %}
-    <p id="prompt-category" class="italic text-gray-600 dark:text-gray-400 hidden"></p>
-    {% endif %}
-    <p id="intro-tagline" class="text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
+    <details id="prompt-meta" class="text-gray-600 dark:text-gray-400">
+      <summary class="sr-only">Prompt details</summary>
+      {% if category %}
+      <p id="prompt-category" class="italic">{{ category }}</p>
+      {% else %}
+      <p id="prompt-category" class="italic hidden"></p>
+      {% endif %}
+      <p id="intro-tagline" class="text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
+    </details>
   </div>
 </section>
 <section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">


### PR DESCRIPTION
## Summary
- collapse the prompt category and tagline behind a details tag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d57c90aa88332afa68e92290ef235