### PR TITLE
Adjust prompt layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -239,7 +239,7 @@ summary::-webkit-details-marker {
 }
 
 #daily-prompt {
-  font-size: clamp(1.75rem, 3vw + 1.2rem, 2.75rem);
+  font-size: clamp(2rem, 3vw + 1.5rem, 3rem);
   font-weight: 600;
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,7 @@
   <meta name="theme-color" content="#1a1a1a">
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-4 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
-  <header class="flex flex-col sm:flex-row justify-between items-center space-y-2 sm:space-y-0 w-full -mx-4 mb-4 sticky top-0 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100 z-10">
+  <header class="flex flex-col sm:flex-row justify-between items-center space-y-2 sm:space-y-0 w-full -mx-4 mb-2 sticky top-0 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100 z-10">
     {% block header_title %}
     <h1 class="welcome-message">Echo Journal</h1>
     {% endblock %}

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -18,7 +18,7 @@
   <div class="p-4 border-b border-gray-300 dark:border-gray-600 mb-2 space-y-1">
     <div class="flex items-center justify-center gap-2">
       <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
-      <button type="button" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-lg" aria-label="New Prompt">Refresh prompt</button>
+      <button type="button" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-sm" aria-label="New Prompt">Refresh prompt</button>
     </div>
     <details id="prompt-meta" class="text-gray-600 dark:text-gray-400">
       <summary class="sr-only">Prompt details</summary>


### PR DESCRIPTION
## Summary
- bring header closer to page content
- enlarge the daily prompt text
- shrink the refresh button text size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d599cd65483328d834581cea7764a