### PR TITLE
Reduce spacing around prompt

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -26,8 +26,8 @@
   <link rel="icon" type="image/x-icon" href="/static/icons/echo_journal_favicon.ico">
   <meta name="theme-color" content="#1a1a1a">
 </head>
-<body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-4 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
-  <header class="flex flex-col sm:flex-row justify-between items-center space-y-2 sm:space-y-0 w-full -mx-4 mb-2 sticky top-0 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100 z-10">
+<body class="min-h-screen flex flex-col items-center justify-start p-4 space-y-2 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100">
+  <header class="flex flex-col sm:flex-row justify-between items-center space-y-2 sm:space-y-0 w-full -mx-4 mb-1 sticky top-0 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100 z-10">
     {% block header_title %}
     <h1 class="welcome-message">Echo Journal</h1>
     {% endblock %}

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -13,9 +13,11 @@
   </h1>
 {% endblock %}
 
+{% block main_classes %}prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-3 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
+
 {% block content %}
 <section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
-  <div class="p-4 mb-2 space-y-1">
+  <div class="p-4 mb-1 space-y-1">
     <div class="flex items-center justify-center gap-2">
       <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
       <button type="button" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-sm" aria-label="New Prompt">Refresh prompt</button>


### PR DESCRIPTION
## Summary
- reduce header margin spacing and body gap
- tighten gap between daily prompt and editor by customizing page layout

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d5f3c679c8332a92608aa998e1659