### PR TITLE
Hide empty location/weather placeholders

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -62,7 +62,7 @@
         console.warn('Reverse geocoding failed:', e);
       }
 
-      // Display it somewhere (optional)
+      const detailsEl = document.getElementById('meta-details');
       const el = document.getElementById('location-display');
       if (el) {
         el.textContent = `📍 ${locationLabel} (±${Math.round(accuracy)}m)`;
@@ -70,6 +70,8 @@
         el.dataset.lon = longitude;
         el.dataset.accuracy = accuracy;
         el.dataset.locationName = locationLabel;
+        el.classList.remove('hidden');
+        detailsEl?.classList.remove('hidden');
       }
 
       const weatherEl = document.getElementById('weather-display');
@@ -78,6 +80,8 @@
         if (weather) {
           const icon = weatherIcons[weather.code] || '';
           weatherEl.textContent = `${icon} ${weather.temperature}\u00B0C`.trim();
+          weatherEl.classList.remove('hidden');
+          detailsEl?.classList.remove('hidden');
         }
       }
     },

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -72,10 +72,11 @@
     <button id="save-button" class="block w-full max-w-sm mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>
 
-  <section class="w-full mx-auto text-center mt-2 space-y-1">
+  <details id="meta-details" class="w-full mx-auto text-center mt-2 space-y-1 hidden">
+    <summary class="cursor-pointer font-semibold">Location &amp; Weather</summary>
     <div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 italic hidden"></div>
     <div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 italic hidden"></div>
-  </section>
+  </details>
 
     <footer class="w-full mx-auto mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide" id="save-status" aria-live="polite" role="status">
     <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">


### PR DESCRIPTION
## Summary
- Wrap location and weather displays in a collapsed details block hidden by default
- Unhide details once geolocation or weather data is fetched

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ddaf1c39083329af9cbd588874489