### PR TITLE
Add focus mode toggle to echo journal

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -177,6 +177,24 @@
       catEl.classList.toggle('hidden', !currentCategory);
     }
 
+    const focusToggle = document.getElementById('focus-toggle');
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('focus') === '1') {
+      document.body.classList.add('focus-mode');
+    }
+    if (focusToggle) {
+      const updateLabel = () => {
+        const active = document.body.classList.contains('focus-mode');
+        focusToggle.textContent = active ? 'Exit Focus' : 'Focus mode';
+        focusToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
+      };
+      updateLabel();
+      focusToggle.addEventListener('click', () => {
+        document.body.classList.toggle('focus-mode');
+        updateLabel();
+      });
+    }
+
     const toolbar = document.getElementById('md-toolbar');
     const textarea = document.getElementById('journal-text');
     if (textarea) {

--- a/static/style.css
+++ b/static/style.css
@@ -247,3 +247,12 @@ summary::-webkit-details-marker {
 #intro-tagline {
   font-size: clamp(0.75rem, 0.6vw + 0.6rem, 0.875rem);
 }
+
+/* Focus mode hides navigation links and gives the editor more space */
+.focus-mode #main-nav {
+  display: none;
+}
+
+.focus-mode textarea.journal-textarea {
+  min-height: 70vh;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
     {% block header_title %}
     <h1 class="welcome-message">Echo Journal</h1>
     {% endblock %}
-    <nav class="space-x-4 text-sm" aria-label="Main navigation">
+    <nav id="main-nav" class="space-x-4 text-sm" aria-label="Main navigation">
       <a href="/" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'home' %}font-semibold{% endif %}">Home</a>
       <a href="/archive" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'archive' %}font-semibold{% endif %}">Archive</a>
       <a href="/stats" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 hover:underline {% if active_page == 'stats' %}font-semibold{% endif %}">Stats</a>

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -18,10 +18,11 @@
 {% block content %}
 <section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
   <div class="p-4 mb-1 space-y-1">
-    <div class="flex items-center justify-center gap-2">
-      <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
-      <button type="button" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-sm" aria-label="New Prompt">Refresh prompt</button>
-    </div>
+      <div class="flex items-center justify-center gap-2">
+        <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
+        <button type="button" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-sm" aria-label="New Prompt">Refresh prompt</button>
+        <button type="button" id="focus-toggle" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-sm" aria-pressed="false">Focus mode</button>
+      </div>
     <details id="prompt-meta" class="text-gray-600 dark:text-gray-400">
       <summary class="sr-only">Prompt details</summary>
       {% if category %}


### PR DESCRIPTION
## Summary
- add focus mode toggle to journaling page to hide navigation links and enlarge textarea
- adjust styles for focus mode and support ?focus=1 query

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ddc2d050883328bee7024aa1b41b6