### PR TITLE
Refine prompt and focus controls

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -140,6 +140,8 @@
     };
 
     const welcomeEl = document.getElementById('welcome-message');
+    const focusToggle = document.getElementById('focus-toggle');
+    const newBtn = document.getElementById('new-prompt');
     let delay = 0;
     if (welcomeEl) {
       const wantsGreeting = welcomeEl.dataset.dynamicGreeting === 'true';
@@ -170,14 +172,16 @@
     }
     if (promptEl) {
       promptEl.textContent = currentPrompt;
-      animateText(promptEl, delay + 300, 15, 40);
+      const promptDelay = animateText(promptEl, delay + 300, 15, 40);
+      const buttons = [newBtn, focusToggle].filter(Boolean);
+      if (buttons.length) {
+        setTimeout(() => buttons.forEach(btn => btn.classList.remove('hidden')), promptDelay + 200);
+      }
     }
     if (catEl) {
       catEl.textContent = currentCategory || '';
       catEl.classList.toggle('hidden', !currentCategory);
     }
-
-    const focusToggle = document.getElementById('focus-toggle');
     const params = new URLSearchParams(window.location.search);
     if (params.get('focus') === '1') {
       document.body.classList.add('focus-mode');
@@ -185,7 +189,7 @@
     if (focusToggle) {
       const updateLabel = () => {
         const active = document.body.classList.contains('focus-mode');
-        focusToggle.textContent = active ? 'Exit Focus' : 'Focus mode';
+        focusToggle.textContent = active ? 'Exit Focus' : 'Focus';
         focusToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
       };
       updateLabel();
@@ -197,9 +201,17 @@
 
     const toolbar = document.getElementById('md-toolbar');
     const textarea = document.getElementById('journal-text');
+    const saveButton = document.getElementById('save-button');
     if (textarea) {
       // Ensure the field height matches preloaded content
       textarea.dispatchEvent(new Event('input'));
+    }
+    if (textarea && saveButton) {
+      const toggleSaveVisibility = () => {
+        saveButton.classList.toggle('hidden', textarea.value.trim() === '');
+      };
+      toggleSaveVisibility();
+      textarea.addEventListener('input', toggleSaveVisibility);
     }
     if (toolbar && textarea) {
       toolbar.addEventListener('click', (e) => {
@@ -239,7 +251,6 @@
       });
     }
 
-    const newBtn = document.getElementById('new-prompt');
     if (newBtn && promptEl) {
       newBtn.addEventListener('click', async (e) => {
         e.preventDefault();
@@ -260,7 +271,6 @@
       });
     }
 
-    const saveButton = document.getElementById('save-button');
     if (saveButton) {
       saveButton.addEventListener('click', async () => {
         if (saveButton.disabled) {

--- a/static/style.css
+++ b/static/style.css
@@ -207,6 +207,29 @@ summary::-webkit-details-marker {
 }
 
 
+.prompt-btn {
+  font-size: 0.75rem;
+  color: #4b5563;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  background-color: #f9fafb;
+}
+
+.prompt-btn:hover {
+  background-color: #e5e7eb;
+}
+
+.dark .prompt-btn {
+  color: #d1d5db;
+  border-color: #4b5563;
+  background-color: #374151;
+}
+
+.dark .prompt-btn:hover {
+  background-color: #4b5563;
+}
+
 .hidden { display: none; }
 
 .meta-card {
@@ -250,6 +273,10 @@ summary::-webkit-details-marker {
 
 /* Focus mode hides navigation links and gives the editor more space */
 .focus-mode #main-nav {
+  display: none;
+}
+
+.focus-mode .welcome-message {
   display: none;
 }
 

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -20,8 +20,8 @@
   <div class="p-4 mb-1 space-y-1">
       <div class="flex items-center justify-center gap-2">
         <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
-        <button type="button" id="new-prompt" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-sm" aria-label="New Prompt">Refresh prompt</button>
-        <button type="button" id="focus-toggle" class="text-blue-600 visited:text-blue-400 dark:text-blue-400 dark:visited:text-blue-300 text-sm" aria-pressed="false">Focus mode</button>
+        <button type="button" id="new-prompt" class="prompt-btn hidden" aria-label="New Prompt">Refresh</button>
+        <button type="button" id="focus-toggle" class="prompt-btn hidden" aria-pressed="false" aria-label="Toggle focus mode">Focus</button>
       </div>
     <details id="prompt-meta" class="text-gray-600 dark:text-gray-400">
       <summary class="sr-only">Prompt details</summary>
@@ -70,7 +70,7 @@
   </fieldset>
 </details>
   <section class="w-full mx-auto mt-6 p-4 rounded-xl">
-    <button id="save-button" class="block w-full max-w-sm mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
+    <button id="save-button" class="hidden block w-full max-w-sm mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>
 
   <details id="meta-details" class="w-full mx-auto text-center mt-2 space-y-1 hidden">


### PR DESCRIPTION
## Summary
- style refresh and focus buttons as subtle controls and reveal them after the prompt animation completes
- hide save entry button until text is entered
- hide welcome message in focus mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dde6fe0788332a58f2a5fcd5cf43c