### PR TITLE
Hide weather details while shrinking prompt buttons

### DIFF
--- a/main.py
+++ b/main.py
@@ -270,6 +270,7 @@ async def save_entry(data: dict):
     prompt = data.get("prompt")
     category = data.get("category")
     location = data.get("location") or {}
+    weather = data.get("weather")
     mood = data.get("mood")
     energy = data.get("energy")
 
@@ -291,7 +292,7 @@ async def save_entry(data: dict):
         )
     first_save = not file_path.exists()
     if first_save:
-        frontmatter = await build_frontmatter(location)
+        frontmatter = await build_frontmatter(location, weather)
     else:
         frontmatter = await read_existing_frontmatter(file_path)
 

--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -62,26 +62,20 @@
         console.warn('Reverse geocoding failed:', e);
       }
 
-      const detailsEl = document.getElementById('meta-details');
       const el = document.getElementById('location-display');
       if (el) {
-        el.textContent = `📍 ${locationLabel} (±${Math.round(accuracy)}m)`;
         el.dataset.lat = latitude;
         el.dataset.lon = longitude;
         el.dataset.accuracy = accuracy;
         el.dataset.locationName = locationLabel;
-        el.classList.remove('hidden');
-        detailsEl?.classList.remove('hidden');
       }
 
       const weatherEl = document.getElementById('weather-display');
       if (weatherEl) {
         const weather = await fetchWeather(latitude, longitude);
         if (weather) {
-          const icon = weatherIcons[weather.code] || '';
-          weatherEl.textContent = `${icon} ${weather.temperature}\u00B0C`.trim();
-          weatherEl.classList.remove('hidden');
-          detailsEl?.classList.remove('hidden');
+          weatherEl.dataset.temp = weather.temperature;
+          weatherEl.dataset.code = weather.code;
         }
       }
     },
@@ -291,6 +285,14 @@
             label: locEl.dataset.locationName || ''
           };
         }
+        const weatherEl = document.getElementById('weather-display');
+        let weather = null;
+        if (weatherEl && weatherEl.dataset.temp && weatherEl.dataset.code) {
+          weather = {
+            temperature: parseFloat(weatherEl.dataset.temp),
+            code: parseInt(weatherEl.dataset.code, 10)
+          };
+        }
         const mood = document.getElementById('mood-select').value;
         const energy = document.getElementById('energy-select').value;
 
@@ -299,7 +301,7 @@
           const response = await fetch('/entry', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ date, content, prompt, category, location, mood, energy })
+            body: JSON.stringify({ date, content, prompt, category, location, weather, mood, energy })
           });
 
           if (!response.ok) {

--- a/static/style.css
+++ b/static/style.css
@@ -208,9 +208,9 @@ summary::-webkit-details-marker {
 
 
 .prompt-btn {
-  font-size: 0.75rem;
+  font-size: 0.625rem;
   color: #4b5563;
-  padding: 0.125rem 0.5rem;
+  padding: 0.0625rem 0.375rem;
   border: 1px solid #d1d5db;
   border-radius: 0.25rem;
   background-color: #f9fafb;

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -121,6 +121,21 @@ def test_category_saved_in_frontmatter(test_client):
     assert "category: Fun" in text
 
 
+def test_weather_saved_when_provided(test_client):
+    """Weather data is stored in frontmatter when supplied."""
+    payload = {
+        "date": "2021-01-01",
+        "content": "entry",
+        "prompt": "prompt",
+        "location": {"lat": 1, "lon": 2, "accuracy": 0, "label": "X"},
+        "weather": {"temperature": 20, "code": 1},
+    }
+    resp = test_client.post("/entry", json=payload)
+    assert resp.status_code == 200
+    text = (main.DATA_DIR / "2021-01-01.md").read_text(encoding="utf-8")
+    assert "weather: 20°C code 1" in text
+
+
 def test_save_entry_missing_fields(test_client):
     """Saving with missing required fields should return an error."""
     resp = test_client.post("/entry", json={"date": "2020-01-02"})

--- a/weather_utils.py
+++ b/weather_utils.py
@@ -1,6 +1,6 @@
 """Helpers for building frontmatter with optional weather data."""
 
-from typing import Optional
+from typing import Optional, Dict
 from datetime import datetime
 
 import httpx
@@ -42,19 +42,22 @@ def time_of_day_label(now: datetime | None = None) -> str:
     return "Night"
 
 
-async def build_frontmatter(location: dict) -> str:
-    """Return a YAML frontmatter string based on the provided location."""
+async def build_frontmatter(location: dict, weather: Optional[Dict[str, float]] = None) -> str:
+    """Return a YAML frontmatter string based on the provided location and weather."""
     lat = float(location.get("lat") or 0)
     lon = float(location.get("lon") or 0)
     label = location.get("label") or ""
-    weather = await fetch_weather(lat, lon)
+    if weather and "temperature" in weather and "code" in weather:
+        weather_str = f"{weather['temperature']}°C code {int(weather['code'])}"
+    else:
+        weather_str = await fetch_weather(lat, lon)
     wotd = await fetch_word_of_day()
 
     lines = []
     if label:
         lines.append(f"location: {label}")
-    if weather:
-        lines.append(f"weather: {weather}")
+    if weather_str:
+        lines.append(f"weather: {weather_str}")
     lines.append(f"save_time: {time_of_day_label()}")
     if wotd:
         lines.append(f"wotd: {wotd}")


### PR DESCRIPTION
## Summary
- Reduce "Refresh" and "Focus" prompt buttons to a smaller size
- Capture location and weather data without revealing them in the UI
- Persist provided weather details in entry front matter with tests

## Testing
- `npm run build:css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688de23e6160833281ed7892cb8b18e9