### PR TITLE
Handle new prompts.yaml structure

### DIFF
--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import prompt_utils
+
+
+def test_generate_prompt_filters_and_category(tmp_path, monkeypatch):
+    """generate_prompt respects tag filtering and derives categories from IDs."""
+    content = (
+        "- id: cat-001\n"
+        "  prompt: 'A'\n"
+        "  tags:\n    - alpha\n"
+        "  energy: 1\n"
+        "  mood: meh\n"
+        "- id: dog_001\n"
+        "  prompt: 'B'\n"
+        "  tags:\n    - beta\n"
+        "  energy: 2\n"
+        "  mood: ok\n"
+    )
+    pfile = tmp_path / "prompts.yaml"
+    pfile.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(prompt_utils, "PROMPTS_FILE", pfile)
+    prompt_utils._prompts_cache = {"data": None, "mtime": None}
+
+    res = asyncio.run(prompt_utils.generate_prompt(tags=["beta"]))
+
+    assert res["prompt"] == "B"
+    assert res["category"] == "Dog"
+    assert res["tags"] == ["beta"]


### PR DESCRIPTION
## Summary
- refactor prompt loading and generation to read list-based `prompts.yaml`
- derive categories from prompt IDs and return extra metadata
- cover new prompt format with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dfc5333bc8332b754cd86ad007add