### PR TITLE
Refactor prompt generation to random mood/energy filtering

### DIFF
--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -4,17 +4,17 @@ import prompt_utils
 
 
 def test_generate_prompt_filters_and_category(tmp_path, monkeypatch):
-    """generate_prompt respects tag filtering and derives categories from IDs."""
+    """generate_prompt respects mood/energy filters and derives categories."""
     content = (
         "- id: cat-001\n"
         "  prompt: 'A'\n"
         "  tags:\n    - alpha\n"
-        "  energy: 1\n"
-        "  mood: meh\n"
+        "  energy: 3\n"
+        "  mood: ok\n"
         "- id: dog_001\n"
         "  prompt: 'B'\n"
         "  tags:\n    - beta\n"
-        "  energy: 2\n"
+        "  energy: 1\n"
         "  mood: ok\n"
     )
     pfile = tmp_path / "prompts.yaml"
@@ -22,7 +22,7 @@ def test_generate_prompt_filters_and_category(tmp_path, monkeypatch):
     monkeypatch.setattr(prompt_utils, "PROMPTS_FILE", pfile)
     prompt_utils._prompts_cache = {"data": None, "mtime": None}
 
-    res = asyncio.run(prompt_utils.generate_prompt(tags=["beta"]))
+    res = asyncio.run(prompt_utils.generate_prompt(mood="ok", energy=2))
 
     assert res["prompt"] == "B"
     assert res["category"] == "Dog"


### PR DESCRIPTION
## Summary
- remove ActivationEngine dependency from prompt selection
- filter prompts by mood and energy and choose randomly
- update unit tests for new prompt filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e002c402083328bfdaa69fc9dfac3