### PR TITLE
Refactor journal layout for prompt flow

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -16,39 +16,8 @@
 {% block main_classes %}prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-3 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
 
 {% block content %}
-<section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
-  <div class="p-4 mb-1 space-y-1">
-      <div class="flex items-center justify-center gap-2">
-        <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
-        <button type="button" id="new-prompt" class="prompt-btn hidden" aria-label="New Prompt">Refresh</button>
-        <button type="button" id="focus-toggle" class="prompt-btn hidden" aria-pressed="false" aria-label="Toggle focus mode">Focus</button>
-      </div>
-    <details id="prompt-meta" class="text-gray-600 dark:text-gray-400">
-      <summary class="sr-only">Prompt details</summary>
-      {% if category %}
-      <p id="prompt-category" class="italic">{{ category }}</p>
-      {% else %}
-      <p id="prompt-category" class="italic hidden"></p>
-      {% endif %}
-      <p id="intro-tagline" class="text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
-    </details>
-  </div>
-</section>
-<section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">
-  <div id="md-toolbar" class="space-x-2 justify-center markdown-toolbar" aria-label="Formatting toolbar" role="toolbar">
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="bold" title="Bold" aria-label="Bold"><strong>B</strong></button>
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="italic" title="Italic" aria-label="Italic"><em>I</em></button>
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="header" title="Heading" aria-label="Heading">H1</button>
-    <button type="button" class="md-btn text-base md:text-2xl" data-action="list" title="List" aria-label="List">&#8226;</button>
-  </div>
-  <label for="journal-text" class="sr-only">Journal entry</label>
-  <textarea id="journal-text" class="journal-textarea" autofocus
-    placeholder="Write freely… describe what happened, how you felt, what you noticed, or anything else that stands out."
-    oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
-    rows="4">{{ content }}</textarea>
-</section>
-<details id="mood-energy-details" class="mt-4 w-full">
-  <summary class="cursor-pointer text-center font-semibold">Mood &amp; Energy (optional)</summary>
+<section id="mood-energy-section" class="mt-4 w-full text-center space-y-2">
+  <p class="font-semibold">Mood &amp; Energy (optional)</p>
   <fieldset id="mood-energy" class="mt-2 flex flex-wrap justify-center gap-4 border-0 m-0 p-0">
     <legend class="sr-only">Mood and energy (optional)</legend>
     <label for="mood-select" class="sr-only">Mood</label>
@@ -68,7 +37,43 @@
       <option value="energized">⚡ Energized</option>
     </select>
   </fieldset>
-</details>
+  <button type="button" id="get-prompt" class="prompt-btn">Get Prompt</button>
+</section>
+<section id="prompt-section" class="hidden">
+  <section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
+    <div class="p-4 mb-1 space-y-1">
+        <div class="flex items-center justify-center gap-2">
+          <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
+          <button type="button" id="new-prompt" class="prompt-btn hidden" aria-label="New Prompt">Refresh</button>
+          <button type="button" id="focus-toggle" class="prompt-btn hidden" aria-pressed="false" aria-label="Toggle focus mode">Focus</button>
+        </div>
+      <details id="prompt-meta" class="text-gray-600 dark:text-gray-400">
+        <summary class="sr-only">Prompt details</summary>
+        {% if category %}
+        <p id="prompt-category" class="italic">{{ category }}</p>
+        {% else %}
+        <p id="prompt-category" class="italic hidden"></p>
+        {% endif %}
+        <p id="intro-tagline" class="text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
+      </details>
+    </div>
+  </section>
+</section>
+<section id="editor-section" class="hidden">
+  <section class="w-full mx-auto editor-container p-4 rounded-xl paper-card">
+    <div id="md-toolbar" class="space-x-2 justify-center markdown-toolbar" aria-label="Formatting toolbar" role="toolbar">
+      <button type="button" class="md-btn text-base md:text-2xl" data-action="bold" title="Bold" aria-label="Bold"><strong>B</strong></button>
+      <button type="button" class="md-btn text-base md:text-2xl" data-action="italic" title="Italic" aria-label="Italic"><em>I</em></button>
+      <button type="button" class="md-btn text-base md:text-2xl" data-action="header" title="Heading" aria-label="Heading">H1</button>
+      <button type="button" class="md-btn text-base md:text-2xl" data-action="list" title="List" aria-label="List">&#8226;</button>
+    </div>
+    <label for="journal-text" class="sr-only">Journal entry</label>
+    <textarea id="journal-text" class="journal-textarea" autofocus
+      placeholder="Write freely… describe what happened, how you felt, what you noticed, or anything else that stands out."
+      oninput="this.style.height='auto'; this.style.height=(this.scrollHeight)+'px'"
+      rows="4">{{ content }}</textarea>
+  </section>
+</section>
   <section class="w-full mx-auto mt-6 p-4 rounded-xl">
     <button id="save-button" class="hidden block w-full max-w-sm mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>


### PR DESCRIPTION
## Summary
- Move mood/energy selections to top and expose a Get Prompt button
- Hide prompt display and editor until a prompt is fetched

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688e03c78f5c83328f617e9f904d7d00