### PR TITLE
Allow prompt filtering by mood and energy

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,9 +176,8 @@ async def index(request: Request):
         category = meta.get("category", "")
         wotd = meta.get("wotd", "")
     else:
-        prompt_data = await generate_prompt()
-        prompt = prompt_data["prompt"]
-        category = prompt_data.get("category", "")
+        prompt = ""
+        category = ""
         entry = ""
         wotd = ""
 
@@ -676,9 +675,9 @@ async def stats_page(request: Request):
 
 
 @app.get("/api/new_prompt")
-async def new_prompt() -> dict:
+async def new_prompt(mood: str | None = None, energy: int | None = None) -> dict:
     """Return a freshly generated journal prompt."""
-    return await generate_prompt()
+    return await generate_prompt(mood=mood, energy=energy)
 
 
 @app.get("/api/reverse_geocode")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -844,21 +844,26 @@ def test_reverse_geocode_network_error(test_client, monkeypatch):
 def test_new_prompt_endpoint(test_client, monkeypatch):
     """/api/new_prompt returns a generated prompt."""
 
-    async def fake_prompt():
+    captured: dict[str, object] = {}
+
+    async def fake_prompt(*, mood=None, energy=None):
+        captured["mood"] = mood
+        captured["energy"] = energy
         return {"prompt": "P", "category": "Test"}
 
     monkeypatch.setattr(main, "generate_prompt", fake_prompt)
 
-    resp = test_client.get("/api/new_prompt")
+    resp = test_client.get("/api/new_prompt", params={"mood": "ok", "energy": 2})
 
     assert resp.status_code == 200
     assert resp.json() == {"prompt": "P", "category": "Test"}
+    assert captured == {"mood": "ok", "energy": 2}
 
 
 def test_save_entry_after_refresh(test_client, monkeypatch):
     """Entries saved after fetching a new prompt use that prompt."""
 
-    async def fake_prompt():
+    async def fake_prompt(*, mood=None, energy=None):  # pylint: disable=unused-argument
         return {"prompt": "New", "category": "Cat"}
 
     monkeypatch.setattr(main, "generate_prompt", fake_prompt)


### PR DESCRIPTION
## Summary
- Defer prompt generation on initial page load so the client can request one later
- Extend `/api/new_prompt` to accept optional `mood` and `energy` query params
- Update endpoint tests for the new prompt API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e082625748332b7d9498e00fa981f