### PR TITLE
Map energy selections to numeric values before fetching new prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ photos: []
 
 Additional keys may be introduced in future integrations (e.g., facts, mood tracking). Unknown keys are ignored.
 
+## Energy level mapping
+
+Energy selections from the UI are translated to integers before hitting `/api/new_prompt`.
+This allows the backend to score prompts based on numeric intensity.
+
+| Energy | Value |
+| ------ | ----- |
+| `drained` | 1 |
+| `low` | 2 |
+| `ok` | 3 |
+| `energized` | 4 |
+
 ## Setup
 
 Echo Journal runs as a small FastAPI application. Copy `.env.example` to

--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -6,6 +6,7 @@
   const promptKey = `ej-prompt-${entryDate}`;
   const readonly = cfg.readonly === true || cfg.readonly === "true";
   const energyLevels = { drained: 1, low: 2, ok: 3, energized: 4 };
+  const getEnergyValue = (level) => energyLevels[level] || null;
 
   async function fetchWeather(lat, lon) {
     try {
@@ -259,8 +260,9 @@
       getPromptBtn.addEventListener('click', async () => {
         const mood = moodSelect ? moodSelect.value : '';
         const energyStr = energySelect ? energySelect.value : '';
-        if (!mood || !energyStr) return;
-        const params = new URLSearchParams({ mood, energy: energyLevels[energyStr] });
+        const energy = getEnergyValue(energyStr);
+        if (!mood || !energy) return;
+        const params = new URLSearchParams({ mood, energy });
         try {
           const res = await fetch(`/api/new_prompt?${params.toString()}`);
           if (res.ok) {
@@ -290,10 +292,10 @@
         e.preventDefault();
         const mood = moodSelect ? moodSelect.value : '';
         const energyStr = energySelect ? energySelect.value : '';
+        const energy = getEnergyValue(energyStr);
         const params = new URLSearchParams();
         if (mood) params.append('mood', mood);
-        const mappedEnergy = energyLevels[energyStr];
-        if (mappedEnergy) params.append('energy', mappedEnergy);
+        if (energy) params.append('energy', energy);
         const url = `/api/new_prompt${params.toString() ? `?${params.toString()}` : ''}`;
         try {
           const res = await fetch(url);


### PR DESCRIPTION
## Summary
- convert energy strings to integers via lookup before calling `/api/new_prompt`
- document energy-to-integer mapping for contributors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e093657b4833299f03d99231ca702