### PR TITLE
Add prompt selection debug info

### DIFF
--- a/main.py
+++ b/main.py
@@ -675,9 +675,13 @@ async def stats_page(request: Request):
 
 
 @app.get("/api/new_prompt")
-async def new_prompt(mood: str | None = None, energy: int | None = None) -> dict:
+async def new_prompt(
+    mood: str | None = None,
+    energy: int | None = None,
+    debug: bool = False,
+) -> dict:
     """Return a freshly generated journal prompt."""
-    return await generate_prompt(mood=mood, energy=energy)
+    return await generate_prompt(mood=mood, energy=energy, debug=debug)
 
 
 @app.get("/api/reverse_geocode")

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -27,3 +27,27 @@ def test_generate_prompt_filters_and_category(tmp_path, monkeypatch):
     assert res["prompt"] == "B"
     assert res["category"] == "Dog"
     assert res["tags"] == ["beta"]
+
+
+def test_generate_prompt_debug(tmp_path, monkeypatch):
+    """generate_prompt returns debug info when requested."""
+    content = (
+        "- id: cat-001\n"
+        "  prompt: 'A'\n"
+        "  mood: ok\n"
+        "  energy: 5\n"
+        "- id: dog_001\n"
+        "  prompt: 'B'\n"
+        "  mood: ok\n"
+        "  energy: 1\n"
+    )
+    pfile = tmp_path / "prompts.yaml"
+    pfile.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(prompt_utils, "PROMPTS_FILE", pfile)
+    prompt_utils._prompts_cache = {"data": None, "mtime": None}
+
+    res = asyncio.run(prompt_utils.generate_prompt(mood="ok", energy=1, debug=True))
+
+    assert res["id"] == "dog_001"
+    assert res["debug"]["initial"] == ["cat-001", "dog_001"]
+    assert res["debug"]["after_energy"] == ["dog_001"]


### PR DESCRIPTION
## Summary
- allow prompt generation to expose candidate filtering details
- expose debug option via `/api/new_prompt` endpoint
- cover debug behavior with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e0b1f45a88332a5e9f3a1dbc89db7