### PR TITLE
Save mood and energy in journal entry frontmatter

### DIFF
--- a/main.py
+++ b/main.py
@@ -270,8 +270,8 @@ async def save_entry(data: dict):
     category = data.get("category")
     location = data.get("location") or {}
     weather = data.get("weather")
-    mood = data.get("mood")
-    energy = data.get("energy")
+    mood = bleach.clean(data.get("mood") or "").strip() or None
+    energy = bleach.clean(data.get("energy") or "").strip() or None
 
     if not entry_date or not content or not prompt:
         return JSONResponse(

--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -350,8 +350,8 @@
             code: parseInt(weatherEl.dataset.code, 10)
           };
         }
-        const mood = document.getElementById('mood-select').value;
-        const energy = document.getElementById('energy-select').value;
+        const mood = moodSelect ? moodSelect.value : '';
+        const energy = energySelect ? energySelect.value : '';
 
         const status = document.getElementById('save-status');
         try {

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -136,6 +136,22 @@ def test_weather_saved_when_provided(test_client):
     assert "weather: 20°C code 1" in text
 
 
+def test_mood_and_energy_saved(test_client):
+    """Selected mood and energy values are stored in frontmatter."""
+    payload = {
+        "date": "2021-04-01",
+        "content": "entry",
+        "prompt": "prompt",
+        "mood": "joyful",
+        "energy": "energized",
+    }
+    resp = test_client.post("/entry", json=payload)
+    assert resp.status_code == 200
+    text = (main.DATA_DIR / "2021-04-01.md").read_text(encoding="utf-8")
+    assert "mood: joyful" in text
+    assert "energy: energized" in text
+
+
 def test_save_entry_missing_fields(test_client):
     """Saving with missing required fields should return an error."""
     resp = test_client.post("/entry", json={"date": "2020-01-02"})


### PR DESCRIPTION
## Summary
- Clean and persist submitted mood and energy values in entry frontmatter
- Ensure the client includes mood and energy selections when saving entries
- Test that saved entries contain the chosen mood and energy

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e19d6d41c83329558de1f87a01d66