### PR TITLE
feat: prompt restart when yesterday missing

### DIFF
--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -16,6 +16,11 @@
 {% block main_classes %}prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-3 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
 
 {% block content %}
+{% if missing_yesterday %}
+<section id="restart-notice" class="mt-4 w-full text-center text-sm text-gray-600 dark:text-gray-300">
+  Looks like there's no entry for yesterday. Restart from today?
+</section>
+{% endif %}
 <section id="mood-energy-section" class="mt-4 w-full text-center space-y-2">
   <p class="font-semibold">Mood &amp; Energy (optional)</p>
   <fieldset id="mood-energy" class="mt-2 flex flex-wrap justify-center gap-4 border-0 m-0 p-0">

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -46,3 +46,25 @@ def test_calculate_streaks_deduplicates_dates(tmp_path, monkeypatch):
         "current_week_streak": 2,
         "longest_week_streak": 2,
     }
+
+
+def test_days_since_last_entry_various_gaps(tmp_path):
+    """_days_since_last_entry returns expected gaps."""
+    today = date(2024, 1, 10)
+
+    # No entries yet
+    assert main._days_since_last_entry(tmp_path, today) is None
+
+    # Entry for yesterday -> gap 1
+    (tmp_path / "2024-01-09.md").touch()
+    assert main._days_since_last_entry(tmp_path, today) == 1
+
+    # Replace with entry two days ago -> gap 2
+    (tmp_path / "2024-01-09.md").unlink()
+    (tmp_path / "2024-01-08.md").touch()
+    assert main._days_since_last_entry(tmp_path, today) == 2
+
+    # Entry five days ago -> gap 5
+    (tmp_path / "2024-01-08.md").unlink()
+    (tmp_path / "2024-01-05.md").touch()
+    assert main._days_since_last_entry(tmp_path, today) == 5


### PR DESCRIPTION
## Summary
- detect gaps since last entry and flag when yesterday's entry is missing
- gently prompt users to restart journaling from today
- test gap detection and restart notice behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e1d11a4ec83328711822a5cc7c4e7