### PR TITLE
Fix prompt animation triggering while selecting mood/energy

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -210,7 +210,9 @@
       const mood = moodSelect ? moodSelect.value : '';
       const energyStr = energySelect ? energySelect.value : '';
       const energy = getEnergyValue(energyStr);
+      // Only fetch when both fields are chosen and user is done interacting
       if (!mood || !energy) return;
+      if (document.activeElement === moodSelect || document.activeElement === energySelect) return;
       try {
         const params = new URLSearchParams({ mood, energy });
         const res = await fetch(`/api/new_prompt?${params.toString()}`);
@@ -225,8 +227,14 @@
       } catch (_) {}
     };
 
-    if (moodSelect) moodSelect.addEventListener('change', maybeFetchPrompt);
-    if (energySelect) energySelect.addEventListener('change', maybeFetchPrompt);
+    if (moodSelect) {
+      moodSelect.addEventListener('change', maybeFetchPrompt);
+      moodSelect.addEventListener('blur', maybeFetchPrompt);
+    }
+    if (energySelect) {
+      energySelect.addEventListener('change', maybeFetchPrompt);
+      energySelect.addEventListener('blur', maybeFetchPrompt);
+    }
     maybeFetchPrompt();
     const params = new URLSearchParams(window.location.search);
     if (params.get('focus') === '1') {


### PR DESCRIPTION
## Summary
- only fetch new prompt when mood & energy selectors both have values and neither is focused
- ensure blur events also trigger prompt fetching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e252c3374833292cb19e856daf251