### PR TITLE
Fix prompt initial load visibility

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -203,7 +203,7 @@
       if (energySelect) energySelect.disabled = true;
       moodEnergyLocked = true;
     }
-    if (currentPrompt && hasEntryContent) {
+    if (currentPrompt) {
       revealPrompt();
       promptShown = true;
     }


### PR DESCRIPTION
## Summary
- Ensure the daily prompt is revealed immediately when present, regardless of existing entry content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e46f36e74833290848f6a8195c544