### PR TITLE
Expose env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ The `.env` file configures optional integrations and runtime paths:
   matching `Authorization` header.
 
 Set any of these variables in `.env` or your environment to tailor the app to
-your setup.
+your setup. The **Settings** page lists current values and lets you edit them;
+changes are saved to `.env` and take effect after restarting the server.
 
 ### Disabling integrations
 

--- a/env_utils.py
+++ b/env_utils.py
@@ -1,0 +1,40 @@
+"""Helpers for reading and writing .env files."""
+
+from pathlib import Path
+from typing import Dict
+
+ENV_PATH = Path(".env")
+
+
+def load_env(path: Path | None = None) -> Dict[str, str]:
+    """Return key/value pairs from a .env file."""
+    if path is None:
+        path = ENV_PATH
+    env: Dict[str, str] = {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                env[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return env
+
+
+def save_env(values: Dict[str, str], path: Path | None = None) -> Dict[str, str]:
+    """Merge ``values`` into the .env file and return updated mapping."""
+    if path is None:
+        path = ENV_PATH
+    data = load_env(path)
+    data.update(values)
+    lines = [f"{k}={v}" for k, v in data.items()]
+    content = "\n".join(lines) + "\n"
+    try:
+        with path.open("w", encoding="utf-8") as fh:
+            fh.write(content)
+    except OSError:
+        pass
+    return data

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ from jellyfin_utils import update_song_metadata, update_media_metadata
 from prompt_utils import generate_prompt
 from weather_utils import build_frontmatter, time_of_day_label
 from activation_engine_utils import fetch_tags
+from env_utils import load_env, save_env
 
 
 # Provide pathlib.Path.is_relative_to on Python < 3.9
@@ -769,6 +770,18 @@ async def proxy_asset(asset_id: str):
         raise HTTPException(status_code=resp.status_code, detail="Asset fetch failed")
     content_type = resp.headers.get("content-type", "application/octet-stream")
     return Response(content=resp.content, media_type=content_type)
+
+
+@app.get("/api/env")
+async def get_env_settings() -> Dict[str, str]:
+    """Return key/value pairs from the .env file."""
+    return load_env()
+
+
+@app.post("/api/env")
+async def update_env_settings(values: Dict[str, str]) -> Dict[str, str]:
+    """Merge provided values into the .env file and return the updated mapping."""
+    return save_env(values)
 
 
 @app.post("/api/backfill_songs")

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,6 +19,12 @@
   </fieldset>
 </form>
 
+<form id="env-form" class="w-full max-w-md mx-auto mt-8 text-sm text-gray-700 dark:text-gray-300 space-y-2">
+  <p class="text-center text-gray-500 dark:text-gray-400">Edit server environment variables. Changes require a restart.</p>
+  <div id="env-fields" class="space-y-2"></div>
+  <button type="button" id="save-env" class="mx-auto block bg-blue-600 text-white px-4 py-1 rounded">Save</button>
+</form>
+
 <footer class="w-full max-w-md mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
   <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">
   Echo Journal
@@ -86,6 +92,40 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   save();
+
+  const envForm = document.getElementById('env-form');
+  if (envForm) {
+    const envFields = envForm.querySelector('#env-fields');
+    fetch('/api/env')
+      .then((r) => r.json())
+      .then((vars) => {
+        Object.entries(vars).forEach(([key, value]) => {
+          const label = document.createElement('label');
+          label.className = 'flex items-center gap-2 justify-between';
+          label.textContent = key;
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.id = `env-${key}`;
+          input.value = value;
+          input.className = 'flex-1 border rounded px-2 py-1 bg-white dark:bg-[#333]';
+          label.appendChild(input);
+          envFields.appendChild(label);
+        });
+      });
+
+    envForm.querySelector('#save-env').addEventListener('click', async () => {
+      const vars = {};
+      envFields.querySelectorAll('input').forEach((input) => {
+        const k = input.id.replace('env-', '');
+        vars[k] = input.value;
+      });
+      await fetch('/api/env', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(vars),
+      });
+    });
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary
- add helper to read/update `.env`
- allow Settings page to edit server environment variables
- document editable env vars

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e478ab8e883329f2115b3e0b9d509