### PR TITLE
Delay prompt generation until mood and energy selected

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -203,7 +203,9 @@
       if (energySelect) energySelect.disabled = true;
       moodEnergyLocked = true;
     }
-    if (currentPrompt) {
+    const initialMood = moodSelect ? moodSelect.value : '';
+    const initialEnergy = energySelect ? energySelect.value : '';
+    if (currentPrompt && (hasEntryContent || (initialMood && initialEnergy))) {
       revealPrompt();
       promptShown = true;
     }
@@ -237,7 +239,6 @@
       energySelect.addEventListener('change', maybeFetchPrompt);
       energySelect.addEventListener('blur', maybeFetchPrompt);
     }
-    maybeFetchPrompt();
     const params = new URLSearchParams(window.location.search);
     if (params.get('focus') === '1') {
       document.body.classList.add('focus-mode');


### PR DESCRIPTION
## Summary
- Reveal saved prompt only when an entry exists or both mood and energy selections are present.
- Remove initial prompt fetch so prompts are generated only after selecting mood and energy.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e52b55b688332bd1afc96a6985941