### PR TITLE
Fetch prompt immediately after mood and energy selection

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -214,9 +214,8 @@
       const mood = moodSelect ? moodSelect.value : '';
       const energyStr = energySelect ? energySelect.value : '';
       const energy = getEnergyValue(energyStr);
-      // Only fetch when both fields are chosen and user is done interacting
+      // Only fetch when both fields are chosen
       if (!mood || !energy) return;
-      if (document.activeElement === moodSelect || document.activeElement === energySelect) return;
       try {
         const params = new URLSearchParams({ mood, energy });
         const res = await fetch(`/api/new_prompt?${params.toString()}`);


### PR DESCRIPTION
## Summary
- Trigger prompt fetch as soon as both mood and energy are selected, removing need to click elsewhere

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e598979a48332bde68c995872ad98