### PR TITLE
Prevent stale prompt flashing in Echo Journal

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -216,6 +216,11 @@
       const energy = getEnergyValue(energyStr);
       // Only fetch when both fields are chosen
       if (!mood || !energy) return;
+      // Hide any existing prompt to avoid flashing stale content
+      if (promptSection) promptSection.classList.add('hidden');
+      if (promptEl) promptEl.textContent = '';
+      if (editorSection) editorSection.classList.add('hidden');
+      [newBtn, focusToggle].filter(Boolean).forEach(btn => btn.classList.add('hidden'));
       try {
         const params = new URLSearchParams({ mood, energy });
         const res = await fetch(`/api/new_prompt?${params.toString()}`);


### PR DESCRIPTION
## Summary
- Hide existing prompt, editor and controls before fetching a new prompt when mood and energy are selected
- Avoids displaying stale prompt content

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5dccaeec83328a69685f05115cb3