### PR TITLE
Hide prompt until text animation begins

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -219,6 +219,7 @@
       // Hide any existing prompt to avoid flashing stale content
       if (promptSection) promptSection.classList.add('hidden');
       if (promptEl) promptEl.textContent = '';
+      if (promptEl) promptEl.classList.add('opacity-0');
       if (editorSection) editorSection.classList.add('hidden');
       [newBtn, focusToggle].filter(Boolean).forEach(btn => btn.classList.add('hidden'));
       try {


### PR DESCRIPTION
## Summary
- ensure prompt is invisible after clearing text to avoid flashes when fetching new prompts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e63decdcc8332806cb94bc55cecf1