### PR TITLE
docs: clarify Google service account key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,10 @@ changes are saved to `.env` and take effect after restarting the server.
 
 ### Google Cloud service account credentials
 
-Some integrations require a Google Cloud service account. Provide a JSON
-credentials file that includes keys such as `client_email`, `token_uri`, and
-`private_key`.
+Some integrations require a Google Cloud service account. Provide the full JSON
+key downloaded from the Google Cloud console; it must include top-level fields
+like `type`, `client_email`, `token_uri`, and `private_key`. Keys that only
+contain a `"web"` section are OAuth client configs and will not work.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- clarify that Google service account JSON must include top-level fields like `type`, `client_email`, and `token_uri`
- note that OAuth client files with only a `"web"` section won't work
- retain instructions on exporting `GOOGLE_APPLICATION_CREDENTIALS`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e638f31488332b6ff7ba830922e5e