### PR TITLE
Add definitions to Wordnik word of the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ location: Example Place
 weather: 18°C code 1
 save_time: Evening
 wotd: luminous
+wotd_def: emitting light
 category: Gratitude
 photos: []
 ```
@@ -146,6 +147,7 @@ photos: []
 | `weather` | Temperature and weather code from Open‑Meteo. | Parsed by `format_weather` to show an icon and temperature. |
 | `save_time` | Morning/Afternoon/Evening/Night recorded at save time. | Provides context for when the entry was written. |
 | `wotd` | Wordnik word of the day. | Displayed in the entry sidebar and as an icon in the archive list. |
+| `wotd_def` | Definition for the word of the day. | Shown alongside the word in entry views. |
 | `category` | Prompt category selected when saving. | Stored for filtering and prompt history. |
 | `photos` | List of photo objects from Immich, initially empty. | Adds a 📸 icon in the archive and shows thumbnails under the entry. |
 

--- a/main.py
+++ b/main.py
@@ -177,11 +177,13 @@ async def index(request: Request):
             entry = body.strip()
         category = meta.get("category", "")
         wotd = meta.get("wotd", "")
+        wotd_def = meta.get("wotd_def", "")
     else:
         prompt = ""
         category = ""
         entry = ""
         wotd = ""
+        wotd_def = ""
 
     gap = _days_since_last_entry(DATA_DIR, today)
     missing_yesterday = gap is None or gap > 1
@@ -198,6 +200,7 @@ async def index(request: Request):
             "readonly": False,  # Explicit
             "active_page": "home",
             "wotd": wotd,
+            "wotd_def": wotd_def,
             "missing_yesterday": missing_yesterday,
         },
     )
@@ -567,6 +570,7 @@ async def archive_entry(request: Request, entry_date: str):
             "location": meta.get("location", ""),
             "weather": format_weather(meta["weather"]) if meta.get("weather") else "",
             "wotd": meta.get("wotd", ""),
+            "wotd_def": meta.get("wotd_def", ""),
             "photos": photos,
             "songs": songs,
             "media": media,

--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -26,7 +26,7 @@
       {% if weather %}{{ weather }}{% endif %}
       </div>
       <div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 mt-1 italic {% if not wotd %}hidden{% endif %}">
-        {% if wotd %}📖 {{ wotd }}{% endif %}
+        {% if wotd %}📖 {{ wotd }}{% if wotd_def %} — {{ wotd_def }}{% endif %}{% endif %}
       </div>
       <details id="songs-display" class="text-xs text-gray-600 dark:text-gray-300 mt-3 {% if not songs %}hidden{% endif %}">
         <summary class="cursor-pointer font-medium">🎵 Today's Songs</summary>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -114,7 +114,7 @@ def test_word_of_day_in_frontmatter(test_client, monkeypatch):
     """Wordnik word of the day is saved in frontmatter when available."""
 
     async def fake_word():
-        return "serendipity"
+        return "serendipity", "fortunate discovery"
 
     monkeypatch.setattr(weather_utils, "fetch_word_of_day", fake_word)
     payload = {"date": "2020-10-10", "content": "entry", "prompt": "prompt"}
@@ -122,13 +122,14 @@ def test_word_of_day_in_frontmatter(test_client, monkeypatch):
     assert resp.status_code == 200
     text = (main.DATA_DIR / "2020-10-10.md").read_text(encoding="utf-8")
     assert "wotd: serendipity" in text
+    assert "wotd_def: fortunate discovery" in text
 
 
 def test_wordnik_disabled_in_frontmatter(test_client, monkeypatch):
     """Wordnik data should be omitted when integration is disabled."""
 
     async def fake_word():
-        return "serendipity"
+        return "serendipity", "fortunate discovery"
 
     monkeypatch.setattr(weather_utils, "fetch_word_of_day", fake_word)
     payload = {
@@ -141,6 +142,7 @@ def test_wordnik_disabled_in_frontmatter(test_client, monkeypatch):
     assert resp.status_code == 200
     text = (main.DATA_DIR / "2020-10-11.md").read_text(encoding="utf-8")
     assert "wotd:" not in text
+    assert "wotd_def:" not in text
 
 
 def test_category_saved_in_frontmatter(test_client):
@@ -545,6 +547,7 @@ def test_view_entry_shows_wotd(test_client):
     """Word of the day from frontmatter should appear in view page."""
     content = """---
 wotd: luminous
+wotd_def: emitting light
 photos: []
 ---
 # Prompt
@@ -556,12 +559,14 @@ E"""
     resp = test_client.get("/archive/2021-08-01")
     assert resp.status_code == 200
     assert "luminous" in resp.text
+    assert "emitting light" in resp.text
 
 
 def test_archive_shows_wotd_icon(test_client):
     """Entries with a word of the day show an icon in the archive."""
     content = """---
 wotd: zephyr
+wotd_def: gentle breeze
 photos: []
 ---
 # Prompt

--- a/weather_utils.py
+++ b/weather_utils.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict
 from datetime import datetime
 
 import httpx
+import yaml
 
 from wordnik_utils import fetch_word_of_day
 
@@ -59,9 +60,11 @@ async def build_frontmatter(
         weather_str = f"{weather['temperature']}°C code {int(weather['code'])}"
     else:
         weather_str = await fetch_weather(lat, lon)
-    wotd = None
+    wotd_word = wotd_def = None
     if integrations.get("wordnik", True):
         wotd = await fetch_word_of_day()
+        if wotd:
+            wotd_word, wotd_def = wotd
 
     lines = []
     if label:
@@ -69,8 +72,11 @@ async def build_frontmatter(
     if weather_str:
         lines.append(f"weather: {weather_str}")
     lines.append(f"save_time: {time_of_day_label()}")
-    if wotd:
-        lines.append(f"wotd: {wotd}")
+    if wotd_word:
+        lines.append(f"wotd: {wotd_word}")
+        if wotd_def:
+            dumped = yaml.safe_dump(wotd_def, explicit_end=False).strip().splitlines()[0]
+            lines.append(f"wotd_def: {dumped}")
     if integrations.get("immich", True):
         lines.append("photos: []")
     return "\n".join(lines)

--- a/wordnik_utils.py
+++ b/wordnik_utils.py
@@ -1,24 +1,37 @@
 """Utility functions for interacting with the Wordnik API."""
 
 import os
-from typing import Optional
+from typing import Optional, Tuple
+
 import httpx
 
 WORDNIK_URL = "https://api.wordnik.com/v4/words.json/wordOfTheDay"
 
-async def fetch_word_of_day() -> Optional[str]:
-    """Return today's Wordnik word of the day if available."""
+
+async def fetch_word_of_day() -> Optional[Tuple[str, str]]:
+    """Return today's Wordnik word of the day and definition if available."""
+
     api_key = os.getenv("WORDNIK_API_KEY")
     if not api_key:
         return None
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(WORDNIK_URL, params={"api_key": api_key}, timeout=10)
+            resp = await client.get(
+                WORDNIK_URL, params={"api_key": api_key}, timeout=10
+            )
             resp.raise_for_status()
             data = resp.json()
             word = data.get("word")
+            definition = ""
+            defs = data.get("definitions")
+            if isinstance(defs, list) and defs:
+                first = defs[0]
+                if isinstance(first, dict):
+                    text = first.get("text")
+                    if isinstance(text, str):
+                        definition = text
             if isinstance(word, str):
-                return word
+                return word, definition
     except (httpx.HTTPError, ValueError):
         return None
     return None


### PR DESCRIPTION
## Summary
- fetch Wordnik word of the day with its definition
- store `wotd_def` in frontmatter and surface it in entry views
- document and test new word-of-the-day definition support

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ea3764e6c83328143b71f3710a7c4