### PR TITLE
docs: sync roadmap and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Echo Journal Roadmap
+# Echo Journal
+
+Echo Journal is a minimalist FastAPI journaling app that stores Markdown
+entries enriched with optional metadata like mood, energy, location, weather,
+photos and media. Daily prompts can be refreshed or even generated on demand
+with an AI helper. Below is the project roadmap and current feature set.
 
 ## Phase 1: Core MVP ✅ Completed
 
@@ -63,16 +68,16 @@
 
 ### Enrichment and UX Enhancements
 
-- **Auto-generated prompt selection**  
-  - Add What you watched (from Jellyfin) to the metadata
-  - Uses contextual signals (Jellyfin, Immich, Last.fm, local time, weather)  
+- **Auto-generated prompt selection**
+  - Add What you watched (from Jellyfin) to the metadata ✅
+  - Uses contextual signals (Jellyfin, Immich, Last.fm, local time, weather)
   - Backend rules or scoring engine selects from `prompts.yaml`
   - Contextual input logged into `.meta.json` or frontmatter
-  - AI-assisted prompts (“Need inspiration?” feature).  
-  - Optional "New Prompt" link to gently refresh the daily suggestion if it doesn't resonate.  
-    - Subtle secondary text that fades in on hover/tap.  
-    - Client-side localStorage ensures the prompt stays consistent after saving.  
-  - Optional secure remote access (auth, VPN/reverse proxy).  
+  - AI-assisted prompts (“Need inspiration?” feature) ✅
+  - Optional "New Prompt" link to gently refresh the daily suggestion if it doesn't resonate ✅
+    - Subtle secondary text that fades in on hover/tap.
+    - Client-side localStorage ensures the prompt stays consistent after saving.
+  - Optional secure remote access (auth, VPN/reverse proxy) ✅
 
 - **Minimalist journal screen mode**  
   - One visible prompt only  

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,9 +46,9 @@
 ## Phase 5: Enrichment and polish (in progress)
 - Document YAML frontmatter structure in the README ✅ Completed
 - Add optional "Fact of the Day" integration
-- Provide an AI-assisted prompt helper
-- Allow refreshing the prompt via a "New Prompt" link
-- Evaluate secure remote access options and toggles for integrations
+- Provide an AI-assisted prompt helper ✅ Completed
+- Allow refreshing the prompt via a "New Prompt" link ✅ Completed
+- Evaluate secure remote access options and toggles for integrations ✅ Completed
 
 ### AuADHD Support Enhancements
 - Mood + energy tagging (stored client-side)


### PR DESCRIPTION
## Summary
- clarify Echo Journal scope and AI prompt capabilities in the README
- mark AI prompt helper, refresh link, and remote-access options as complete on the roadmap

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f28a4ea948332b726b6d5b4cedafe