### PR TITLE
refactor: align settings page with yaml overrides

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,10 +19,10 @@
   </fieldset>
 </form>
 
-<form id="env-form" class="w-full max-w-md mx-auto mt-8 text-sm text-gray-700 dark:text-gray-300 space-y-2">
-  <p class="text-center text-gray-500 dark:text-gray-400">Edit server environment variables. Changes require a restart.</p>
-  <div id="env-fields" class="space-y-2"></div>
-  <button type="button" id="save-env" class="mx-auto block bg-blue-600 text-white px-4 py-1 rounded">Save</button>
+<form id="settings-form" class="w-full max-w-md mx-auto mt-8 text-sm text-gray-700 dark:text-gray-300 space-y-2">
+  <p class="text-center text-gray-500 dark:text-gray-400">Edit server settings. Values are saved to <code>settings.yaml</code> and override <code>.env</code>. Changes require a restart.</p>
+  <div id="settings-fields" class="space-y-2"></div>
+  <button type="button" id="save-settings" class="mx-auto block bg-blue-600 text-white px-4 py-1 rounded">Save</button>
 </form>
 
 <footer class="w-full max-w-md mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">
@@ -93,9 +93,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
   save();
 
-  const envForm = document.getElementById('env-form');
-  if (envForm) {
-    const envFields = envForm.querySelector('#env-fields');
+  const settingsForm = document.getElementById('settings-form');
+  if (settingsForm) {
+    const settingsFields = settingsForm.querySelector('#settings-fields');
     fetch('/api/env')
       .then((r) => r.json())
       .then((vars) => {
@@ -105,18 +105,18 @@ document.addEventListener("DOMContentLoaded", () => {
           label.textContent = key;
           const input = document.createElement('input');
           input.type = 'text';
-          input.id = `env-${key}`;
+          input.id = `setting-${key}`;
           input.value = value;
           input.className = 'flex-1 border rounded px-2 py-1 bg-white dark:bg-[#333]';
           label.appendChild(input);
-          envFields.appendChild(label);
+          settingsFields.appendChild(label);
         });
       });
 
-    envForm.querySelector('#save-env').addEventListener('click', async () => {
+    settingsForm.querySelector('#save-settings').addEventListener('click', async () => {
       const vars = {};
-      envFields.querySelectorAll('input').forEach((input) => {
-        const k = input.id.replace('env-', '');
+      settingsFields.querySelectorAll('input').forEach((input) => {
+        const k = input.id.replace('setting-', '');
         vars[k] = input.value;
       });
       await fetch('/api/env', {


### PR DESCRIPTION
## Summary
- tweak settings page to save config in `settings.yaml`
- rename form and fields to reflect YAML overrides

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f418edec883329557968c3a23d3d0