### PR TITLE
Persist integration settings in settings.yaml

### DIFF
--- a/main.py
+++ b/main.py
@@ -189,6 +189,14 @@ async def index(request: Request):
     gap = _days_since_last_entry(DATA_DIR, today)
     missing_yesterday = gap is None or gap > 1
 
+    settings = load_settings()
+    integrations = {
+        "wordnik": settings.get("INTEGRATION_WORDNIK", "true").lower() != "false",
+        "immich": settings.get("INTEGRATION_IMMICH", "true").lower() != "false",
+        "jellyfin": settings.get("INTEGRATION_JELLYFIN", "true").lower() != "false",
+        "fact": settings.get("INTEGRATION_FACT", "true").lower() != "false",
+    }
+
     return templates.TemplateResponse(
         request,
         "echo_journal.html",
@@ -203,6 +211,7 @@ async def index(request: Request):
             "wotd": wotd,
             "wotd_def": wotd_def,
             "missing_yesterday": missing_yesterday,
+            "integrations": integrations,
         },
     )
 

--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -8,7 +8,7 @@
   const energyLevels = { drained: 1, low: 2, ok: 3, energized: 4 };
   const getEnergyValue = (level) => energyLevels[level] || null;
   const defaultIntegrations = { wordnik: true, immich: true, jellyfin: true, fact: true };
-  const integrationSettings = { ...defaultIntegrations, ...JSON.parse(localStorage.getItem('ej-integrations') || '{}') };
+  const integrationSettings = { ...defaultIntegrations, ...(cfg.integrations || {}) };
 
   async function fetchWeather(lat, lon) {
     try {

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -99,7 +99,8 @@
         entryDate: "{{ date }}",
         prompt: {{ prompt | tojson }},
         category: {{ category | tojson }},
-        readonly: {{ 'true' if readonly else 'false' }}
+        readonly: {{ 'true' if readonly else 'false' }},
+        integrations: {{ integrations | tojson }}
       };
     </script>
     <script src="/static/echo_journal.js"></script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -8,19 +8,15 @@
 
 {% block content %}
 
-<form id="integration-settings" class="w-full max-w-md mx-auto text-sm text-gray-700 dark:text-gray-300 space-y-4">
-  <p class="text-center text-gray-500 dark:text-gray-400">Enable or disable optional integrations. Changes persist only in this browser.</p>
-  <fieldset class="space-y-2 text-left">
+<form id="settings-form" class="w-full max-w-md mx-auto text-sm text-gray-700 dark:text-gray-300 space-y-4">
+  <p class="text-center text-gray-500 dark:text-gray-400">Enable or disable optional integrations and edit server settings. Values are saved to <code>settings.yaml</code> and override <code>.env</code>. Changes require a restart.</p>
+  <fieldset id="integration-settings" class="space-y-2 text-left">
     <legend class="sr-only">Integrations</legend>
     <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-wordnik" class="mr-2">Wordnik word of the day</label>
     <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-immich" class="mr-2">Immich photos</label>
     <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-jellyfin" class="mr-2">Jellyfin media</label>
     <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-fact" class="mr-2">Fact of the day</label>
   </fieldset>
-</form>
-
-<form id="settings-form" class="w-full max-w-md mx-auto mt-8 text-sm text-gray-700 dark:text-gray-300 space-y-2">
-  <p class="text-center text-gray-500 dark:text-gray-400">Edit server settings. Values are saved to <code>settings.yaml</code> and override <code>.env</code>. Changes require a restart.</p>
   <div id="settings-fields" class="space-y-2"></div>
   <button type="button" id="save-settings" class="mx-auto block bg-blue-600 text-white px-4 py-1 rounded">Save</button>
 </form>
@@ -76,29 +72,27 @@ document.addEventListener("DOMContentLoaded", () => {
     animateText(welcomeEl, 0, 60, 200);
   }
 
-  const defaultSettings = { wordnik: true, immich: true, jellyfin: true, fact: true };
-  const stored = JSON.parse(localStorage.getItem('ej-integrations') || '{}');
-  const settings = { ...defaultSettings, ...stored };
-  const save = () => localStorage.setItem('ej-integrations', JSON.stringify(settings));
-
-  Object.keys(defaultSettings).forEach((key) => {
-    const cb = document.getElementById(`integration-${key}`);
-    if (!cb) return;
-    cb.checked = settings[key];
-    cb.addEventListener('change', () => {
-      settings[key] = cb.checked;
-      save();
-    });
-  });
-
-  save();
-
   const settingsForm = document.getElementById('settings-form');
   if (settingsForm) {
     const settingsFields = settingsForm.querySelector('#settings-fields');
+    const integrationKeys = {
+      wordnik: 'INTEGRATION_WORDNIK',
+      immich: 'INTEGRATION_IMMICH',
+      jellyfin: 'INTEGRATION_JELLYFIN',
+      fact: 'INTEGRATION_FACT',
+    };
+
     fetch('/api/env')
       .then((r) => r.json())
       .then((vars) => {
+        Object.entries(integrationKeys).forEach(([key, envKey]) => {
+          const cb = document.getElementById(`integration-${key}`);
+          if (cb) {
+            cb.checked = vars[envKey] !== 'false';
+            delete vars[envKey];
+          }
+        });
+
         Object.entries(vars).forEach(([key, value]) => {
           const label = document.createElement('label');
           label.className = 'flex items-center gap-2 justify-between';
@@ -119,6 +113,12 @@ document.addEventListener("DOMContentLoaded", () => {
         const k = input.id.replace('setting-', '');
         vars[k] = input.value;
       });
+
+      Object.entries(integrationKeys).forEach(([key, envKey]) => {
+        const cb = document.getElementById(`integration-${key}`);
+        vars[envKey] = cb && cb.checked ? 'true' : 'false';
+      });
+
       await fetch('/api/env', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Load optional integration toggles from `settings.yaml` and expose them to the journal page
- Move integration checkboxes into Settings form and persist them via `/api/env`
- Read integration flags from config instead of browser storage

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f4f0f6d6c833289966ab72d8da2aa