### PR TITLE
docs: document OpenAI API env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ The `.env` file configures optional integrations and runtime paths:
 - `DATA_DIR`, `APP_DIR`, `PROMPTS_FILE`, `STATIC_DIR`, `TEMPLATES_DIR` –
   internal paths used by the application.
 - `WORDNIK_API_KEY` – enables the Wordnik "word of the day" prompt.
+- `OPENAI_API_KEY` – enables AI-generated prompts via the OpenAI API.
+  Usage may incur costs and is subject to OpenAI's rate limits.
 - `IMMICH_URL` and `IMMICH_API_KEY` – fetch photos from your Immich server
   within the `IMMICH_TIME_BUFFER` hour window.
 - `JELLYFIN_URL`, `JELLYFIN_API_KEY`, and `JELLYFIN_USER_ID` – pull


### PR DESCRIPTION
## Summary
- document `OPENAI_API_KEY` in `.env` configuration to enable AI-generated prompts
- note that using the OpenAI API may incur costs and is subject to rate limits

## Testing
- `black .` (reformatted 10 files; reverted unrelated changes)
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'ai_prompt_utils')*


------
https://chatgpt.com/codex/tasks/task_e_688f585345148332a266ccb1614aeb78