### PR TITLE
Use prompts.yaml in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 JOURNALS_DIR=/path/to/journals
 DATA_DIR=/journals
 APP_DIR=/app
-PROMPTS_FILE=/app/prompts.json
+PROMPTS_FILE=/app/prompts.yaml
 STATIC_DIR=/app/static
 TEMPLATES_DIR=/app/templates
 WORDNIK_API_KEY=


### PR DESCRIPTION
## Summary
- point `PROMPTS_FILE` to `prompts.yaml` in `.env.example`
- confirm docs and docker setup already reference `prompts.yaml`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6cf584088332bd9dad548be130b0