### PR TITLE
docs: document optional Basic Auth and update security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,15 +1,18 @@
 # Security Policy
 
-Echo Journal is intended for use on a trusted local network and does not
-include built‑in authentication. **Do not expose the application directly to the
-internet.** If you need to deploy publicly, place the app behind a secure
-reverse proxy and add your own access controls.
+Echo Journal is intended for use on a trusted local network. The app includes
+optional HTTP Basic authentication that can be enabled by setting the
+`BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment variables. Without
+those variables, there is no built‑in authentication. **Do not expose the
+application directly to the internet.** If you deploy publicly, enable Basic
+Auth and place the app behind a secure reverse proxy with additional access
+controls.
 
 ## Reporting a Vulnerability
 
 If you discover a security issue, please create a new GitHub issue with the
 details and include `[Security]` in the title. You may also email the
-maintainers privately at `security@example.com` if you prefer not to disclose
+maintainers privately at `security@echojournal.org` if you prefer not to disclose
 information publicly.
 
 When reporting a potential vulnerability, please provide:


### PR DESCRIPTION
## Summary
- document enabling HTTP Basic Auth via `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`
- replace placeholder email with security contact address

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ai_prompt_utils')*

------
https://chatgpt.com/codex/tasks/task_e_688f6d83021c8332a16f4a393cc4cd92