### PR TITLE
chore: use multi-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
+# Build stage for compiling CSS with Node.js
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json tailwind_src.css tailwind.config.js ./
+RUN npm ci && mkdir -p static && npm run build:css && npm cache clean --force
+
+# Runtime stage
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-COPY package.json ./
-COPY tailwind_src.css ./
-COPY tailwind.config.js ./
 RUN pip install --no-cache-dir -r requirements.txt
-RUN apt-get update && \
-    apt-get install -y nodejs npm && \
-    npm install && npm run build:css && \
-    npm cache clean --force && \
-    rm -rf node_modules
 COPY . .
+# Copy only the built CSS artifact from the build stage
+COPY --from=build /app/static/tailwind.css ./static/tailwind.css
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- build Tailwind CSS in a Node-based stage
- run app in a slim Python image with only built CSS copied in

## Testing
- `pytest` *(fails: ModuleNotFoundError)*
- `docker build -t echo-journal-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688f6d9bb4a88332a0a8d29d99b81b5d