### PR TITLE
Add tests for auxiliary modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Test configuration to ensure modules see predictable paths."""
+
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+os.environ.setdefault("APP_DIR", str(ROOT))
+os.environ.setdefault("DATA_DIR", str(ROOT / "test_data"))
+os.makedirs(os.environ["DATA_DIR"], exist_ok=True)
+os.environ.setdefault("STATIC_DIR", str(ROOT / "static"))
+os.environ.setdefault("PROMPTS_FILE", str(ROOT / "prompts.yaml"))
+os.environ.setdefault("TEMPLATES_DIR", str(ROOT / "templates"))

--- a/tests/test_activation_engine_utils.py
+++ b/tests/test_activation_engine_utils.py
@@ -1,0 +1,61 @@
+"""Tests for Activation Engine utilities."""
+
+import asyncio
+
+import activation_engine_utils as ae
+
+
+class FakeClient:
+    """Minimal async client to capture POST requests."""
+
+    def __init__(self, data):
+        self._data = data
+        self.captured = {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json=None, timeout=None):
+        self.captured["url"] = url
+        self.captured["json"] = json
+
+        class Response:
+            def __init__(self, data):
+                self._data = data
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._data
+
+        return Response(self._data)
+
+
+def test_fetch_tags(monkeypatch):
+    """``fetch_tags`` should POST data and return strings."""
+    client = FakeClient({"tags": ["joy", 1, "calm"]})
+    monkeypatch.setattr(ae.httpx, "AsyncClient", lambda: client)
+    monkeypatch.setattr(ae, "ACTIVATION_ENGINE_URL", "http://ae")
+
+    tags = asyncio.run(ae.fetch_tags("m", "e", "ctx"))
+
+    assert tags == ["joy", "1", "calm"]
+    assert client.captured["url"] == "http://ae/get-tags"
+    assert client.captured["json"]["mood"] == "m"
+
+
+def test_rank_prompts(monkeypatch):
+    """``rank_prompts`` should return prompts ordered by relevance."""
+    client = FakeClient({"candidates": [{"task": "b"}, {"task": "a"}]})
+    monkeypatch.setattr(ae.httpx, "AsyncClient", lambda: client)
+    monkeypatch.setattr(ae, "ACTIVATION_ENGINE_URL", "http://ae")
+
+    ranked = asyncio.run(ae.rank_prompts(["a", "b"], ["joy"]))
+
+    assert ranked == ["b", "a"]
+    assert client.captured["url"] == "http://ae/rank-tasks"
+    assert client.captured["json"]["user_state"]["mood"] == "joy"

--- a/tests/test_ai_prompt_utils.py
+++ b/tests/test_ai_prompt_utils.py
@@ -1,0 +1,53 @@
+"""Tests for AI prompt utilities."""
+
+import asyncio
+import ai_prompt_utils as ai
+
+
+class FakeClient:
+    """Fake ``httpx.AsyncClient`` for testing."""
+
+    def __init__(self, data):
+        self._data = data
+        self.captured = {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, headers=None, json=None, timeout=None):
+        self.captured["url"] = url
+        self.captured["headers"] = headers
+
+        class Response:
+            def __init__(self, data):
+                self._data = data
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._data
+
+        return Response(self._data)
+
+
+def test_no_api_key(monkeypatch):
+    """When no API key is set, ``fetch_ai_prompt`` returns ``None``."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert asyncio.run(ai.fetch_ai_prompt()) is None
+
+
+def test_fetch_ai_prompt(monkeypatch):
+    """Valid responses should return trimmed prompt text."""
+    client = FakeClient({"choices": [{"text": "  Hello\n"}]})
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(ai.httpx, "AsyncClient", lambda: client)
+
+    prompt = asyncio.run(ai.fetch_ai_prompt())
+
+    assert prompt == "Hello"
+    assert client.captured["url"] == ai.OPENAI_URL
+    assert client.captured["headers"]["Authorization"] == "Bearer x"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+"""Tests for configuration helpers."""
+
+import config
+
+
+def test_get_setting_prefers_settings(monkeypatch):
+    """Values in ``_SETTINGS`` should override environment variables."""
+    monkeypatch.setattr(config, "_SETTINGS", {"A": "from_settings"})
+    monkeypatch.setenv("A", "from_env")
+    assert config._get_setting("A") == "from_settings"
+
+
+def test_get_setting_env(monkeypatch):
+    """Environment variables are used when not in settings."""
+    monkeypatch.setattr(config, "_SETTINGS", {})
+    monkeypatch.setenv("B", "env_val")
+    assert config._get_setting("B", "def") == "env_val"
+
+
+def test_get_setting_default(monkeypatch):
+    """Default value is returned when key missing everywhere."""
+    monkeypatch.setattr(config, "_SETTINGS", {})
+    monkeypatch.delenv("C", raising=False)
+    assert config._get_setting("C", "def") == "def"

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,0 +1,22 @@
+"""Tests for ``env_utils`` helpers."""
+
+from pathlib import Path
+
+import env_utils
+
+
+def test_load_env_parses_pairs(tmp_path):
+    """Key=value pairs should be returned ignoring comments and invalid lines."""
+    p = tmp_path / "test.env"
+    p.write_text("A=1\n#comment\nB=two\ninvalid\n", encoding="utf-8")
+    env = env_utils.load_env(p)
+    assert env == {"A": "1", "B": "two"}
+
+
+def test_save_env_merges_and_writes(tmp_path):
+    """``save_env`` should merge values and write them to disk."""
+    p = tmp_path / "test.env"
+    p.write_text("A=1\n", encoding="utf-8")
+    data = env_utils.save_env({"B": "2"}, p)
+    assert data == {"A": "1", "B": "2"}
+    assert p.read_text(encoding="utf-8") == "A=1\nB=2\n"

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -1,0 +1,22 @@
+"""Tests for ``settings_utils`` helpers."""
+
+import yaml
+
+import settings_utils
+
+
+def test_load_settings_returns_strings(tmp_path):
+    """Values loaded from YAML should be returned as strings."""
+    p = tmp_path / "settings.yaml"
+    p.write_text("A: 1\nB: test\n", encoding="utf-8")
+    data = settings_utils.load_settings(p)
+    assert data == {"A": "1", "B": "test"}
+
+
+def test_save_settings_merges(tmp_path):
+    """``save_settings`` should merge and persist values."""
+    p = tmp_path / "settings.yaml"
+    p.write_text("A: a\n", encoding="utf-8")
+    result = settings_utils.save_settings({"B": "b"}, p)
+    assert result == {"A": "a", "B": "b"}
+    assert yaml.safe_load(p.read_text(encoding="utf-8")) == {"A": "a", "B": "b"}

--- a/tests/test_weather_utils.py
+++ b/tests/test_weather_utils.py
@@ -1,0 +1,63 @@
+"""Tests for weather utility helpers."""
+
+import asyncio
+from datetime import datetime
+
+import weather_utils
+
+class FakeClient:
+    """Minimal ``httpx.AsyncClient`` stand-in for ``fetch_weather``."""
+    def __init__(self, data):
+        self._data = data
+        self.captured = {}
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+    async def get(self, url, params=None, timeout=None):
+        self.captured["url"] = url
+        self.captured["params"] = params
+        class Response:
+            def __init__(self, data):
+                self._data = data
+            def raise_for_status(self):
+                return None
+            def json(self):
+                return self._data
+        return Response(self._data)
+
+def test_fetch_weather(monkeypatch):
+    """Successful requests should yield a formatted weather string."""
+    client = FakeClient({"current_weather": {"temperature": 12, "weathercode": 3}})
+    monkeypatch.setattr(weather_utils.httpx, "AsyncClient", lambda: client)
+    weather = asyncio.run(weather_utils.fetch_weather(1, 2))
+    assert weather == "12\u00b0C code 3"
+    assert client.captured["params"]["latitude"] == 1
+
+def test_fetch_weather_zero():
+    """Lat/Lon of zero should short-circuit to ``None``."""
+    assert asyncio.run(weather_utils.fetch_weather(0, 0)) is None
+
+def test_time_of_day_label():
+    """Time ranges should map to labels."""
+    assert weather_utils.time_of_day_label(datetime(2024, 1, 1, 6)) == "Morning"
+    assert weather_utils.time_of_day_label(datetime(2024, 1, 1, 13)) == "Afternoon"
+    assert weather_utils.time_of_day_label(datetime(2024, 1, 1, 18)) == "Evening"
+    assert weather_utils.time_of_day_label(datetime(2024, 1, 1, 23)) == "Night"
+
+def test_build_frontmatter(monkeypatch):
+    """Frontmatter should include location, weather and word of the day."""
+    async def fake_fetch_weather(lat, lon):
+        return "10\u00b0C code 2"
+    async def fake_wotd():
+        return ("word", "definition")
+    monkeypatch.setattr(weather_utils, "fetch_weather", fake_fetch_weather)
+    monkeypatch.setattr(weather_utils, "fetch_word_of_day", fake_wotd)
+    monkeypatch.setattr(weather_utils, "time_of_day_label", lambda: "Morning")
+    fm = asyncio.run(weather_utils.build_frontmatter({"lat": 1, "lon": 2, "label": "Town"}, integrations={"immich": False}))
+    lines = fm.splitlines()
+    assert "location: Town" in lines
+    assert "weather: 10\u00b0C code 2" in lines
+    assert "wotd: word" in lines
+    assert "wotd_def: definition" in lines
+    assert all("photos" not in line for line in lines)

--- a/tests/test_wordnik_utils.py
+++ b/tests/test_wordnik_utils.py
@@ -1,0 +1,53 @@
+"""Tests for Wordnik utilities."""
+
+import asyncio
+
+import wordnik_utils as wu
+
+
+class FakeClient:
+    """Minimal async client for ``httpx.AsyncClient``."""
+
+    def __init__(self, data):
+        self._data = data
+        self.captured = {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, params=None, timeout=None):
+        self.captured["url"] = url
+        self.captured["params"] = params
+
+        class Response:
+            def __init__(self, data):
+                self._data = data
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._data
+
+        return Response(self._data)
+
+
+def test_no_api_key(monkeypatch):
+    """Missing API key should return ``None``."""
+    monkeypatch.delenv("WORDNIK_API_KEY", raising=False)
+    assert asyncio.run(wu.fetch_word_of_day()) is None
+
+
+def test_fetch_word_of_day(monkeypatch):
+    """Valid responses should return word and definition."""
+    client = FakeClient({"word": "apple", "definitions": [{"text": "a fruit"}]})
+    monkeypatch.setenv("WORDNIK_API_KEY", "k")
+    monkeypatch.setattr(wu.httpx, "AsyncClient", lambda: client)
+
+    result = asyncio.run(wu.fetch_word_of_day())
+
+    assert result == ("apple", "a fruit")
+    assert client.captured["params"]["api_key"] == "k"


### PR DESCRIPTION
## Summary
- test Activation Engine helper methods for tag fetching and prompt ranking
- cover AI prompt retrieval, configuration helpers, and environment utilities
- add tests for YAML settings, weather and Wordnik integrations

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f6f3666c88332b039741e48c966ce