### PR TITLE
Fix lint warnings in activation and jellyfin utils

### DIFF
--- a/activation_engine_utils.py
+++ b/activation_engine_utils.py
@@ -1,3 +1,5 @@
+"""Helpers for talking to the external Activation Engine service."""
+
 import logging
 from typing import List
 import httpx
@@ -41,7 +43,11 @@ async def rank_prompts(prompts: List[str], tags: List[str]) -> List[str]:
             data = resp.json()
             candidates = data.get("candidates")
             if isinstance(candidates, list):
-                return [c.get("task", c) for c in candidates if isinstance(c, dict) or isinstance(c, str)]
+                return [
+                    c.get("task", c)
+                    for c in candidates
+                    if isinstance(c, (dict, str))
+                ]
     except (httpx.HTTPError, ValueError) as exc:
         logger.error("ActivationEngine rank-tasks failed: %s", exc)
     return prompts

--- a/jellyfin_utils.py
+++ b/jellyfin_utils.py
@@ -231,4 +231,3 @@ async def update_media_metadata(date_str: str, journal_path: Path) -> None:
         logger.info("Wrote %d media records to %s", len(media), media_path)
     except OSError as exc:
         logger.error("Failed to write media metadata file: %s", exc)
-


### PR DESCRIPTION
## Summary
- add module docstring and simplify candidate filtering in activation engine utilities
- tidy trailing newline in jellyfin utilities

## Testing
- `pylint activation_engine_utils.py jellyfin_utils.py`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f71a3c7b483328e6c2c515bfc7244