### PR TITLE
docs: sync roadmap and todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ with an AI helper. Below is the project roadmap and current feature set.
 
 ### Enrichment and UX Enhancements
 
+- Gentle restart reminder if yesterday's entry is missing ✅
 - **Auto-generated prompt selection**
   - Add What you watched (from Jellyfin) to the metadata ✅
   - Uses contextual signals (Jellyfin, Immich, Last.fm, local time, weather)
@@ -273,9 +274,10 @@ to your `.env` file.
 ### Disabling integrations
 
 The web UI includes a **Settings** page where optional integrations can be
-toggled per browser. Uncheck Wordnik, Immich, Jellyfin, or Fact integrations to
-disable their metadata. Your choices are stored in `localStorage` and the
-server skips fetching data for any disabled integrations when building
+toggled per browser. Uncheck Wordnik, Immich, or Jellyfin integrations to
+disable their metadata. A future "Fact of the Day" option will also be
+toggleable here once implemented. Your choices are stored in `localStorage` and
+the server skips fetching data for any disabled integrations when building
 frontmatter.
 
 ### Serving behind a VPN or reverse proxy

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,19 +67,19 @@
 - Quick tag reactions
   - Visual + textual buttons: e.g., 😔 Sad, ⚡ Energized, 🪫 Drained
   - Enable archive filtering and stats
-- Streak disruption softness
+- Streak disruption softness ✅ Completed
   - If no entry exists for yesterday, show gentle “Restart from today?” message
   - Avoid shaming or pressure
 - Prompt explanation tooltips
   - Optional: hover or tap to explain what kind of prompts each mood receives
 
 ### Jellyfin Viewing Integration
-- Log TV and movie views per day using Jellyfin API
-- Save to `<date>.media.json` or embed into frontmatter
-- Surface watched content optionally below entry or in archive
-- Support for optional filtering: “Show entries with movies/TV”
+- Log TV and movie views per day using Jellyfin API ✅ Completed
+- Save to `<date>.media.json` or embed into frontmatter ✅ Completed
+- Surface watched content optionally below entry or in archive ✅ Completed
+- Support for optional filtering: “Show entries with movies/TV” ✅ Completed
 - Add “Today I watched…” or “This story reminded me of…” prompts if media exists
-- Reuse Jellyfin API setup already in use for music enrichment
+- Reuse Jellyfin API setup already in use for music enrichment ✅ Completed
 
 ## Phase 6: Insight, Patterning, and Personalization (planned)
 - Filter archive view by mood, energy, tags

--- a/TODO.md
+++ b/TODO.md
@@ -11,16 +11,10 @@ This list only tracks outstanding items from the roadmap.
   - [ ] 10-second journaling mode for quick entries with timestamp and optional metadata.
   - [ ] Time-contextual prompt variations (e.g., "This morning…", "Looking back…", "To Future You…").
   - [ ] Quick tag reactions (visual + textual buttons) enabling archive filtering and stats.
-  - [ ] Streak disruption softness (gentle "Restart from today?" message).
   - [ ] Prompt explanation tooltips describing prompt types.
 
 - [ ] **Jellyfin viewing integration**
-  - [ ] Log TV and movie views per day using Jellyfin API.
-  - [ ] Save to `<date>.media.json` or embed into frontmatter.
-  - [ ] Surface watched content optionally below entry or in archive.
-  - [ ] Support optional filtering: "Show entries with movies/TV".
   - [ ] Add prompts like "Today I watched…" or "This story reminded me of…" if media exists.
-  - [ ] Reuse Jellyfin API setup already in use for music enrichment.
 
 - [ ] **Insight, patterning, and personalization**
   - [ ] Filter archive view by mood, energy, and tags with interactive filter bar.


### PR DESCRIPTION
## Summary
- Document gentle restart reminder and clarify integration toggle behavior
- Mark streak disruption softness and most Jellyfin media tasks as complete in the roadmap
- Trim TODO list to the remaining outstanding items

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f71a01ea483329f1e4c599c997b47