### PR TITLE
chore: quiet test lint warnings

### DIFF
--- a/tests/test_activation_engine_utils.py
+++ b/tests/test_activation_engine_utils.py
@@ -1,5 +1,7 @@
 """Tests for Activation Engine utilities."""
 
+# pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code
+
 import asyncio
 
 import activation_engine_utils as ae

--- a/tests/test_ai_prompt_utils.py
+++ b/tests/test_ai_prompt_utils.py
@@ -1,5 +1,7 @@
 """Tests for AI prompt utilities."""
 
+# pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code
+
 import asyncio
 import ai_prompt_utils as ai
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for configuration helpers."""
 
+# pylint: disable=protected-access
+
 import config
 
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -4,7 +4,7 @@
 # pytest expects tests to accept the ``test_client`` fixture as an argument,
 # which triggers ``redefined-outer-name`` from pylint.
 #
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,too-many-lines,import-outside-toplevel,multiple-imports,wrong-import-order,unused-argument
 
 import json
 import os

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,7 +1,5 @@
 """Tests for ``env_utils`` helpers."""
 
-from pathlib import Path
-
 import env_utils
 
 

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,6 +1,10 @@
+"""Tests for prompt utility helpers."""
+
 import asyncio
 
 import prompt_utils
+
+# pylint: disable=protected-access
 
 
 def test_generate_prompt_filters_and_category(tmp_path, monkeypatch):

--- a/tests/test_weather_utils.py
+++ b/tests/test_weather_utils.py
@@ -1,5 +1,7 @@
 """Tests for weather utility helpers."""
 
+# pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code
+
 import asyncio
 from datetime import datetime
 
@@ -54,7 +56,12 @@ def test_build_frontmatter(monkeypatch):
     monkeypatch.setattr(weather_utils, "fetch_weather", fake_fetch_weather)
     monkeypatch.setattr(weather_utils, "fetch_word_of_day", fake_wotd)
     monkeypatch.setattr(weather_utils, "time_of_day_label", lambda: "Morning")
-    fm = asyncio.run(weather_utils.build_frontmatter({"lat": 1, "lon": 2, "label": "Town"}, integrations={"immich": False}))
+    fm = asyncio.run(
+        weather_utils.build_frontmatter(
+            {"lat": 1, "lon": 2, "label": "Town"},
+            integrations={"immich": False},
+        )
+    )
     lines = fm.splitlines()
     assert "location: Town" in lines
     assert "weather: 10\u00b0C code 2" in lines

--- a/tests/test_wordnik_utils.py
+++ b/tests/test_wordnik_utils.py
@@ -1,5 +1,7 @@
 """Tests for Wordnik utilities."""
 
+# pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code
+
 import asyncio
 
 import wordnik_utils as wu

--- a/wordnik_utils.py
+++ b/wordnik_utils.py
@@ -1,5 +1,7 @@
 """Utility functions for interacting with the Wordnik API."""
 
+# pylint: disable=duplicate-code
+
 import os
 from typing import Optional, Tuple
 


### PR DESCRIPTION
## Summary
- silence pylint docstring, import, and argument warnings across test modules
- ignore duplicate-code false positives in Wordnik helper
- tidy a long weather-utils test line and drop an unused import

## Testing
- `pylint tests wordnik_utils.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f74e29fc88332b9aa7e90e5ed137a