### PR TITLE
docs: add node and css build steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,13 @@ Thank you for your interest in improving Echo Journal! This project welcomes pul
    source .venv/bin/activate
    pip install -r requirements.txt
    ```
-   Alternatively you can run the app through Docker Compose using `docker-compose up --build`.
-3. Run the application locally and verify your changes.
+3. Install Node dependencies and build the CSS:
+   ```sh
+   npm install
+   npm run build:css
+   ```
+   Alternatively, running the project with Docker Compose (`docker-compose up --build`) will perform the above setup steps automatically.
+4. Run the application locally and verify your changes.
 
 ## Style and testing
 


### PR DESCRIPTION
## Summary
- document installing Node dependencies and building CSS
- note that `docker-compose up --build` performs Node and CSS setup automatically

## Testing
- `npm install`
- `npm run build:css`
- `black --check .` *(fails: would reformat files)*
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'wordnik_utils')*


------
https://chatgpt.com/codex/tasks/task_e_688f75a1d608833289e83aa5d9c31054