### PR TITLE
Log env and settings errors

### DIFF
--- a/env_utils.py
+++ b/env_utils.py
@@ -1,9 +1,12 @@
 """Helpers for reading and writing .env files."""
 
+import logging
 from pathlib import Path
 from typing import Dict
 
 ENV_PATH = Path(".env")
+
+logger = logging.getLogger("ej.env")
 
 
 def load_env(path: Path | None = None) -> Dict[str, str]:
@@ -19,8 +22,8 @@ def load_env(path: Path | None = None) -> Dict[str, str]:
                     continue
                 key, value = line.split("=", 1)
                 env[key.strip()] = value.strip()
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.error("Could not read %s: %s", path, exc)
     return env
 
 
@@ -35,6 +38,6 @@ def save_env(values: Dict[str, str], path: Path | None = None) -> Dict[str, str]
     try:
         with path.open("w", encoding="utf-8") as fh:
             fh.write(content)
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.error("Could not write %s: %s", path, exc)
     return data

--- a/settings_utils.py
+++ b/settings_utils.py
@@ -1,11 +1,14 @@
 """Helpers for reading and writing settings.yaml files."""
 
+import logging
 from pathlib import Path
 from typing import Dict, Any
 
 import yaml
 
 SETTINGS_PATH = Path("settings.yaml")
+
+logger = logging.getLogger("ej.settings")
 
 
 def load_settings(path: Path | None = None) -> Dict[str, str]:
@@ -17,7 +20,8 @@ def load_settings(path: Path | None = None) -> Dict[str, str]:
             data: Dict[str, Any] = yaml.safe_load(fh) or {}
             # Ensure keys and values are strings
             return {str(k): str(v) for k, v in data.items()}
-    except OSError:
+    except OSError as exc:
+        logger.error("Could not read %s: %s", path, exc)
         return {}
 
 
@@ -30,6 +34,6 @@ def save_settings(values: Dict[str, str], path: Path | None = None) -> Dict[str,
     try:
         with path.open("w", encoding="utf-8") as fh:
             yaml.safe_dump(data, fh, allow_unicode=True, default_flow_style=False)
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.error("Could not write %s: %s", path, exc)
     return data

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,5 +1,7 @@
 """Tests for ``env_utils`` helpers."""
 
+import logging
+
 import env_utils
 
 
@@ -18,3 +20,21 @@ def test_save_env_merges_and_writes(tmp_path):
     data = env_utils.save_env({"B": "2"}, p)
     assert data == {"A": "1", "B": "2"}
     assert p.read_text(encoding="utf-8") == "A=1\nB=2\n"
+
+
+def test_load_env_logs_error(tmp_path, caplog):
+    """Missing files should log an error and return an empty dict."""
+    p = tmp_path / "missing.env"
+    with caplog.at_level(logging.ERROR, logger="ej.env"):
+        env = env_utils.load_env(p)
+    assert env == {}
+    assert any(str(p) in r.getMessage() for r in caplog.records)
+
+
+def test_save_env_logs_error(tmp_path, caplog):
+    """Errors writing .env files should be logged."""
+    p = tmp_path / "dir" / "test.env"
+    with caplog.at_level(logging.ERROR, logger="ej.env"):
+        data = env_utils.save_env({"A": "1"}, p)
+    assert data == {"A": "1"}
+    assert any(str(p) in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- add logging for .env file read/write failures
- log errors when reading/writing settings files
- test logging behavior for env and settings helpers

## Testing
- `PYTHONPATH=. pytest tests/test_env_utils.py tests/test_settings_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7a1720a883328e232e15d556ba7b