### PR TITLE
Allow timezone customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ docker-compose up --build
 
 This builds the CSS and starts the app on <http://localhost:8510>.
 
+The container defaults to UTC. To use your local timezone, set the
+`TZ` environment variable before starting:
+
+```bash
+TZ=America/Los_Angeles docker-compose up --build
+```
+
+You can also place `TZ=Your/Timezone` in a `.env` file.
+
 ### ActivationEngine companion
 
 Clone the [ActivationEngine](https://github.com/EoghannIrving/ActivationEngine)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./prompts.yaml:/app/prompts.yaml
       - ${JOURNALS_DIR:-/mnt/nas/journals}:/journals
     environment:
-      - TZ=America/New_York
+      - TZ=${TZ:-UTC}
       # Optional API keys for extra features
       - WORDNIK_API_KEY=${WORDNIK_API_KEY:-}
       - IMMICH_URL=${IMMICH_URL:-}


### PR DESCRIPTION
## Summary
- allow TZ to be overridden in docker-compose by environment variable
- document how to set container timezone

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'activation_engine_utils', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688f7bda9370833298e8d0370347b56d