### PR TITLE
Protect env settings endpoint when auth disabled

### DIFF
--- a/main.py
+++ b/main.py
@@ -803,6 +803,8 @@ async def proxy_asset(asset_id: str):
 @app.get("/api/env")
 async def get_env_settings() -> Dict[str, str]:
     """Return key/value pairs from the .env file overridden by settings.yaml."""
+    if not AUTH_ENABLED:
+        raise HTTPException(status_code=403)
     env = load_env()
     settings = load_settings()
     return {**env, **settings}
@@ -811,6 +813,8 @@ async def get_env_settings() -> Dict[str, str]:
 @app.post("/api/env")
 async def update_env_settings(values: Dict[str, str]) -> Dict[str, str]:
     """Merge provided values into settings.yaml and return the updated mapping."""
+    if not AUTH_ENABLED:
+        raise HTTPException(status_code=403)
     save_settings(values)
     env = load_env()
     settings = load_settings()


### PR DESCRIPTION
## Summary
- deny `/api/env` access if basic auth is disabled
- test `/api/env` behavior with auth disabled and enabled

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7f2b5ee48332b97376a1349c8466