### PR TITLE
Sanitize category value before saving

### DIFF
--- a/main.py
+++ b/main.py
@@ -308,7 +308,13 @@ async def save_entry(data: dict):  # pylint: disable=too-many-locals
     entry_date = data.get("date")
     content = data.get("content")
     prompt = data.get("prompt")
-    category = data.get("category")
+    category = (
+        bleach.clean(data.get("category") or "")
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .strip()
+        or None
+    )
     location = data.get("location") or {}
     weather = data.get("weather")
     mood = bleach.clean(data.get("mood") or "").strip() or None


### PR DESCRIPTION
## Summary
- Sanitize incoming `category` values with `bleach` and strip/replace newlines before saving entries
- Add regression test to ensure malicious category input is cleaned and does not break YAML frontmatter

## Testing
- `pytest tests/test_endpoints.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688f81ae739c8332b9c9dc2ce8c09a1a