### PR TITLE
refactor: remove unused save_env helper

### DIFF
--- a/env_utils.py
+++ b/env_utils.py
@@ -1,4 +1,4 @@
-"""Helpers for reading and writing .env files."""
+"""Helpers for reading .env files."""
 
 import logging
 from pathlib import Path
@@ -27,17 +27,3 @@ def load_env(path: Path | None = None) -> Dict[str, str]:
     return env
 
 
-def save_env(values: Dict[str, str], path: Path | None = None) -> Dict[str, str]:
-    """Merge ``values`` into the .env file and return updated mapping."""
-    if path is None:
-        path = ENV_PATH
-    data = load_env(path)
-    data.update(values)
-    lines = [f"{k}={v}" for k, v in data.items()]
-    content = "\n".join(lines) + "\n"
-    try:
-        with path.open("w", encoding="utf-8") as fh:
-            fh.write(content)
-    except OSError as exc:
-        logger.error("Could not write %s: %s", path, exc)
-    return data

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -13,28 +13,10 @@ def test_load_env_parses_pairs(tmp_path):
     assert env == {"A": "1", "B": "two"}
 
 
-def test_save_env_merges_and_writes(tmp_path):
-    """``save_env`` should merge values and write them to disk."""
-    p = tmp_path / "test.env"
-    p.write_text("A=1\n", encoding="utf-8")
-    data = env_utils.save_env({"B": "2"}, p)
-    assert data == {"A": "1", "B": "2"}
-    assert p.read_text(encoding="utf-8") == "A=1\nB=2\n"
-
-
 def test_load_env_logs_error(tmp_path, caplog):
     """Missing files should log an error and return an empty dict."""
     p = tmp_path / "missing.env"
     with caplog.at_level(logging.ERROR, logger="ej.env"):
         env = env_utils.load_env(p)
     assert env == {}
-    assert any(str(p) in r.getMessage() for r in caplog.records)
-
-
-def test_save_env_logs_error(tmp_path, caplog):
-    """Errors writing .env files should be logged."""
-    p = tmp_path / "dir" / "test.env"
-    with caplog.at_level(logging.ERROR, logger="ej.env"):
-        data = env_utils.save_env({"A": "1"}, p)
-    assert data == {"A": "1"}
     assert any(str(p) in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- drop unused save_env function and limit env_utils to reading .env data
- trim tests to only cover load_env behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f84d0fd2c8332acc7300ee6ba4c3e