### PR TITLE
chore: remove unused rank_prompts

### DIFF
--- a/activation_engine_utils.py
+++ b/activation_engine_utils.py
@@ -25,29 +25,3 @@ async def fetch_tags(mood: str, energy: str, context: str) -> List[str]:
     except (httpx.HTTPError, ValueError) as exc:
         logger.error("ActivationEngine get-tags failed: %s", exc)
     return []
-
-async def rank_prompts(prompts: List[str], tags: List[str]) -> List[str]:
-    """Return prompts sorted by relevance via ActivationEngine."""
-    if not ACTIVATION_ENGINE_URL:
-        return prompts
-    url = f"{ACTIVATION_ENGINE_URL.rstrip('/')}/rank-tasks"
-    payload = {"tasks": [
-        {"name": p, "project": "prompt"} for p in prompts
-    ], "user_state": {"mood": None, "energy": 3, "context": {}}}
-    if tags:
-        payload["user_state"]["mood"] = tags[0]
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(url, json=payload, timeout=10)
-            resp.raise_for_status()
-            data = resp.json()
-            candidates = data.get("candidates")
-            if isinstance(candidates, list):
-                return [
-                    c.get("task", c)
-                    for c in candidates
-                    if isinstance(c, (dict, str))
-                ]
-    except (httpx.HTTPError, ValueError) as exc:
-        logger.error("ActivationEngine rank-tasks failed: %s", exc)
-    return prompts

--- a/tests/test_activation_engine_utils.py
+++ b/tests/test_activation_engine_utils.py
@@ -58,16 +58,3 @@ def test_fetch_tags(monkeypatch):
     assert tags == ["joy", "1", "calm"]
     assert client.captured["url"] == "http://ae/get-tags"
     assert client.captured["json"]["mood"] == "m"
-
-
-def test_rank_prompts(monkeypatch):
-    """``rank_prompts`` should return prompts ordered by relevance."""
-    client = FakeClient({"candidates": [{"task": "b"}, {"task": "a"}]})
-    monkeypatch.setattr(ae.httpx, "AsyncClient", lambda: client)
-    monkeypatch.setattr(ae, "ACTIVATION_ENGINE_URL", "http://ae")
-
-    ranked = asyncio.run(ae.rank_prompts(["a", "b"], ["joy"]))
-
-    assert ranked == ["b", "a"]
-    assert client.captured["url"] == "http://ae/rank-tasks"
-    assert client.captured["json"]["user_state"]["mood"] == "joy"


### PR DESCRIPTION
## Summary
- remove unused `rank_prompts` helper from Activation Engine utilities
- drop corresponding tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f851edd588332b906292c2a0d2cbe