### PR TITLE
feat: rename env API to settings-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ frontmatter.
 - Provide a valid contact email in `NOMINATIM_USER_AGENT` to comply with the
   Nominatim usage policy; requests without contact info may be throttled or
   rejected.
-- The `/api/env` endpoint returns environment details for convenience during
-  development. Restrict it to trusted networks or run the app behind a VPN or
-  reverse proxy to avoid leaking secrets.
+- The `/api/settings` endpoint returns server configuration details for
+  convenience during development. Restrict it to trusted networks or run the
+  app behind a VPN or reverse proxy to avoid leaking secrets.
 - Outbound requests now include a 10-second timeout and prompt categories are
   sanitized before saving or rendering, limiting the impact of malicious or
   unexpected input.

--- a/main.py
+++ b/main.py
@@ -55,7 +55,6 @@ from prompt_utils import generate_prompt
 from ai_prompt_utils import fetch_ai_prompt
 from weather_utils import build_frontmatter, time_of_day_label
 from activation_engine_utils import fetch_tags
-from env_utils import load_env
 from settings_utils import load_settings, save_settings
 
 
@@ -767,25 +766,20 @@ async def proxy_asset(asset_id: str):
     return Response(content=resp.content, media_type=content_type)
 
 
-@app.get("/api/env")
-async def get_env_settings() -> Dict[str, str]:
-    """Return key/value pairs from the .env file overridden by settings.yaml."""
+@app.get("/api/settings")
+async def get_settings() -> Dict[str, str]:
+    """Return key/value pairs from ``settings.yaml``."""
     if not AUTH_ENABLED:
         raise HTTPException(status_code=403)
-    env = load_env()
-    settings = load_settings()
-    return {**env, **settings}
+    return load_settings()
 
 
-@app.post("/api/env")
-async def update_env_settings(values: Dict[str, str]) -> Dict[str, str]:
-    """Merge provided values into settings.yaml and return the updated mapping."""
+@app.post("/api/settings")
+async def update_settings(values: Dict[str, str]) -> Dict[str, str]:
+    """Merge provided values into ``settings.yaml`` and return the updated mapping."""
     if not AUTH_ENABLED:
         raise HTTPException(status_code=403)
-    save_settings(values)
-    env = load_env()
-    settings = load_settings()
-    return {**env, **settings}
+    return save_settings(values)
 
 
 @app.post("/api/backfill_songs")

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -82,7 +82,7 @@ document.addEventListener("DOMContentLoaded", () => {
       fact: 'INTEGRATION_FACT',
     };
 
-    fetch('/api/env')
+    fetch('/api/settings')
       .then((r) => r.json())
       .then((vars) => {
         Object.entries(integrationKeys).forEach(([key, envKey]) => {
@@ -119,7 +119,7 @@ document.addEventListener("DOMContentLoaded", () => {
         vars[envKey] = cb && cb.checked ? 'true' : 'false';
       });
 
-      await fetch('/api/env', {
+      await fetch('/api/settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(vars),


### PR DESCRIPTION
## Summary
- simplify env API to read and write only settings.yaml
- rename `/api/env` route to `/api/settings`
- update settings page and tests for new endpoint

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9dda2f8483329e4650cc6a639d6c