### PR TITLE
Install app package in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+RUN pip install .
 # Copy only the built CSS artifact from the build stage
 COPY --from=build /app/static/tailwind.css ./static/tailwind.css
 EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "echo_journal.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Install the project as a package in the runtime image so `echo_journal` modules are discoverable
- Launch the API with `uvicorn` using the fully qualified module path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fabebbf348332a9154abdc1d78335