### PR TITLE
Add Docker ignore rules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Ignore Python bytecode and caches
+__pycache__/
+*.py[cod]
+
+# Exclude virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Node dependencies
+node_modules/
+
+# Test suites
+tests/
+
+# Git and other development files
+.git
+.gitignore
+.github/
+Dockerfile
+docker-compose.yml
+*.md
+*.log
+.env
+.env.*
+.idea/
+.vscode/


### PR DESCRIPTION
## Summary
- reduce Docker build context by ignoring tests, virtualenvs, node modules, and other dev files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fad3aae608332ad658a78699e6c0a