### PR TITLE
Left align prompt and tweak textarea font size

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -49,7 +49,7 @@ textarea.journal-textarea {
   border: none;
   font-family: 'Merriweather', serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Noto Color Emoji', 'EmojiOne Color', 'Android Emoji', 'EmojiSymbols';
-  font-size: clamp(1.125rem, 1vw + 1rem, 1.5rem);
+  font-size: clamp(1rem, 0.9vw + 0.9rem, 1.375rem);
   line-height: 1.7;
   transition: all 0.3s ease;
   box-shadow: none;

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -44,10 +44,10 @@
   </fieldset>
 </section>
 <section id="prompt-section" class="hidden">
-  <section class="w-full mx-auto space-y-2 text-center p-4 rounded-xl">
+  <section class="w-full mx-auto space-y-2 p-4 rounded-xl text-left">
     <div class="p-4 mb-1 space-y-1">
-        <div class="flex items-center justify-center gap-2">
-          <p id="daily-prompt" class="font-sans leading-snug opacity-0">{{ prompt }}</p>
+        <div class="flex items-center gap-2">
+          <p id="daily-prompt" class="font-sans leading-snug opacity-0 text-left">{{ prompt }}</p>
           <button type="button" id="new-prompt" class="prompt-btn hidden" aria-label="New Prompt">Refresh</button>
           <button type="button" id="ai-prompt" class="prompt-btn hidden" aria-label="Need inspiration?">Need inspiration?</button>
           <button type="button" id="focus-toggle" class="prompt-btn hidden" aria-pressed="false" aria-label="Toggle focus mode">Focus</button>


### PR DESCRIPTION
## Summary
- left-align prompt text and container
- slightly reduce journal textarea font size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fb121f55c83329340bf62a137d71b