### PR TITLE
docs: add section links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ entries enriched with optional metadata like mood, energy, location, weather,
 photos and media. Daily prompts can be refreshed or even generated on demand
 with an AI helper. Below is the project roadmap and current feature set.
 
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Environment variables](#environment-variables)
+- [Security considerations](#security-considerations)
+
 ## Prerequisites
 
 - **Python** 3.10+


### PR DESCRIPTION
## Summary
- add quick links to major sections in README

## Testing
- `pytest`
- Rendered README via GitHub Markdown API to verify anchor links

------
https://chatgpt.com/codex/tasks/task_e_688fb5d31d9c8332a2318e2e6d3e3548