### PR TITLE
Expose environment config in settings page

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -80,6 +80,34 @@ elif BASIC_AUTH_USERNAME or BASIC_AUTH_PASSWORD:
         "Both BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD must be set; disabling auth"
     )
 
+# Keys configurable via environment variables and editable from the settings page.
+# Values provided in ``settings.yaml`` override these defaults.
+ENV_SETTING_KEYS = [
+    "JOURNALS_DIR",
+    "DATA_DIR",
+    "APP_DIR",
+    "PROMPTS_FILE",
+    "STATIC_DIR",
+    "TEMPLATES_DIR",
+    "WORDNIK_API_KEY",
+    "OPENAI_API_KEY",
+    "IMMICH_URL",
+    "IMMICH_API_KEY",
+    "IMMICH_TIME_BUFFER",
+    "JELLYFIN_URL",
+    "JELLYFIN_API_KEY",
+    "JELLYFIN_USER_ID",
+    "JELLYFIN_PAGE_SIZE",
+    "JELLYFIN_PLAY_THRESHOLD",
+    "NOMINATIM_USER_AGENT",
+    "LOG_LEVEL",
+    "LOG_FILE",
+    "LOG_MAX_BYTES",
+    "LOG_BACKUP_COUNT",
+    "BASIC_AUTH_USERNAME",
+    "BASIC_AUTH_PASSWORD",
+]
+
 
 # Setup logging to both the console and a rotating file under ``DATA_DIR``
 handlers = [logging.StreamHandler()]
@@ -760,10 +788,12 @@ async def proxy_asset(asset_id: str):
 
 @app.get("/api/settings")
 async def get_settings() -> Dict[str, str]:
-    """Return key/value pairs from ``settings.yaml``."""
+    """Return configuration values from the environment and ``settings.yaml``."""
     if not AUTH_ENABLED:
         raise HTTPException(status_code=403)
-    return load_settings()
+    values = {key: os.getenv(key, "") for key in ENV_SETTING_KEYS}
+    values.update(load_settings())
+    return values
 
 
 @app.post("/api/settings")

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -81,10 +81,41 @@ document.addEventListener("DOMContentLoaded", () => {
       jellyfin: 'INTEGRATION_JELLYFIN',
       fact: 'INTEGRATION_FACT',
     };
+    const envSettingKeys = [
+      'JOURNALS_DIR',
+      'DATA_DIR',
+      'APP_DIR',
+      'PROMPTS_FILE',
+      'STATIC_DIR',
+      'TEMPLATES_DIR',
+      'WORDNIK_API_KEY',
+      'OPENAI_API_KEY',
+      'IMMICH_URL',
+      'IMMICH_API_KEY',
+      'IMMICH_TIME_BUFFER',
+      'JELLYFIN_URL',
+      'JELLYFIN_API_KEY',
+      'JELLYFIN_USER_ID',
+      'JELLYFIN_PAGE_SIZE',
+      'JELLYFIN_PLAY_THRESHOLD',
+      'NOMINATIM_USER_AGENT',
+      'LOG_LEVEL',
+      'LOG_FILE',
+      'LOG_MAX_BYTES',
+      'LOG_BACKUP_COUNT',
+      'BASIC_AUTH_USERNAME',
+      'BASIC_AUTH_PASSWORD',
+    ];
 
     fetch('/api/settings')
       .then((r) => r.json())
       .then((settings) => {
+        envSettingKeys.forEach((key) => {
+          if (!(key in settings)) {
+            settings[key] = '';
+          }
+        });
+
         Object.entries(integrationKeys).forEach(([key, settingKey]) => {
           const cb = document.getElementById(`integration-${key}`);
           if (cb) {

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1120,7 +1120,9 @@ def test_settings_endpoints(tmp_path, monkeypatch):
     token = base64.b64encode(b"user:pass").decode()
     resp3 = client.get("/api/settings", headers={"Authorization": f"Basic {token}"})
     assert resp3.status_code == 200
-    assert resp3.json() == {"FOO": "baz"}
+    body = resp3.json()
+    assert body["FOO"] == "baz"
+    assert body["BASIC_AUTH_USERNAME"] == "user"
 
     resp4 = client.post(
         "/api/settings",


### PR DESCRIPTION
## Summary
- show editable fields for all .env variables on settings page
- include environment values when reading settings via API
- adjust settings tests for new environment data

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fb67fb6e8833284961d7abd37f1a1