### PR TITLE
Use pyproject.toml for CI installs

### DIFF
--- a/.github/workflows/auto-format-and-lint.yml
+++ b/.github/workflows/auto-format-and-lint.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Black and Pylint
       run: |
         pip install black pylint
-        pip install -r requirements.txt
+        pip install .
 
     - name: Auto-format code using Black
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-        pip install -r requirements.txt
+        pip install .
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install .
           pip install pytest httpx
       - name: Run tests
         env:


### PR DESCRIPTION
## Summary
- switch GitHub workflows to install dependencies from `pyproject.toml`

## Testing
- `black --check .` *(fails: would reformat 11 files)*
- `pylint $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fbc72fa9c8332ba1cc6b2773bc5d4