### PR TITLE
Fix lint errors and improve tests

### DIFF
--- a/src/echo_journal/env_utils.py
+++ b/src/echo_journal/env_utils.py
@@ -25,5 +25,3 @@ def load_env(path: Path | None = None) -> Dict[str, str]:
     except OSError as exc:
         logger.error("Could not read %s: %s", path, exc)
     return env
-
-

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -20,6 +20,7 @@ import aiofiles
 import bleach
 import httpx
 import markdown
+import uvicorn
 from fastapi import FastAPI, HTTPException, Request, Query
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -829,8 +830,6 @@ async def backfill_song_metadata() -> dict:
 
 def main() -> None:
     """Run the Echo Journal ASGI application."""
-    import uvicorn
-
     uvicorn.run("echo_journal.main:app", host="0.0.0.0", port=8000)
 
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -928,19 +928,23 @@ def test_reverse_geocode_user_agent(test_client, monkeypatch):
             return False
 
         async def get(self, url, params=None, headers=None, timeout=None):
+            """Return a fake response while capturing request headers."""
             self.request_headers = headers
 
             class Resp:  # pylint: disable=too-few-public-methods
+                """Simple fake HTTP response."""
                 status_code = 200
                 headers = {}
 
                 def json(self):
+                    """Return dummy JSON data."""
                     return {
                         "display_name": "X",
                         "address": {"city": "C", "state": "S", "country": "CO"},
                     }
 
                 def raise_for_status(self):
+                    """No-op status check."""
                     return None
 
             return Resp()
@@ -1086,7 +1090,7 @@ def test_settings_endpoints(tmp_path, monkeypatch):
     settings_file.write_text("FOO: baz\n", encoding="utf-8")
 
     import importlib
-    from echo_journal import settings_utils, config, main
+    from echo_journal import settings_utils, config
 
     monkeypatch.setattr(settings_utils, "SETTINGS_PATH", settings_file)
 

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -18,5 +18,5 @@ def test_load_env_logs_error(tmp_path, caplog):
     p = tmp_path / "missing.env"
     with caplog.at_level(logging.ERROR, logger="ej.env"):
         env = env_utils.load_env(p)
-    assert env == {}
+    assert not env
     assert any(str(p) in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- remove trailing lines in env_utils
- move uvicorn import to module top level
- document test helpers and clean up imports
- simplify empty dict assertion

## Testing
- `pylint src/echo_journal/env_utils.py src/echo_journal/main.py tests/test_endpoints.py tests/test_env_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fbfdb86e883329b8bc399e724a154