### PR TITLE
Ensure settings saved under APP_DIR and auto-create directories

### DIFF
--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -1,12 +1,16 @@
-"""Helpers for reading and writing settings.yaml files."""
+"""Helpers for reading and writing ``settings.yaml`` files."""
 
 import logging
+import os
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 import yaml
 
-SETTINGS_PATH = Path("settings.yaml")
+# ``settings.yaml`` lives inside the application directory which defaults to
+# ``/app`` but can be overridden via the ``APP_DIR`` environment variable.
+APP_DIR = Path(os.getenv("APP_DIR", "/app"))
+SETTINGS_PATH = APP_DIR / "settings.yaml"
 
 logger = logging.getLogger("ej.settings")
 
@@ -32,6 +36,7 @@ def save_settings(values: Dict[str, str], path: Path | None = None) -> Dict[str,
     data = load_settings(path)
     data.update(values)
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as fh:
             yaml.safe_dump(data, fh, allow_unicode=True, default_flow_style=False)
     except OSError as exc:


### PR DESCRIPTION
## Summary
- Resolve `SETTINGS_PATH` under `APP_DIR` so settings file location is deterministic
- Create parent directories before writing settings files
- Add tests for directory creation and `APP_DIR`-relative save

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc3d089b8833283c3a4bf789e786d