### PR TITLE
Load .env at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Python dependencies are defined in `pyproject.toml` and installed with `pip inst
 
    ```bash
    cp .env.example .env
-   # edit .env to point JOURNALS_DIR to a writable path
+   # edit .env to point JOURNALS_DIR to a writable path; it will be loaded on startup
    ```
 
 3. Start the development server:
@@ -188,6 +188,9 @@ changes to take effect.
    ```
 
 ### Environment variables
+
+Echo Journal automatically loads variables from a `.env` file at startup using
+[`python-dotenv`](https://pypi.org/project/python-dotenv/).
 
 The `settings.yaml` file configures optional integrations and runtime paths. It
 is the authoritative source for these values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "bleach==6.2.0",
     "httpx==0.28.1",
     "pyyaml==6.0.2",
+    "python-dotenv==1.0.1",
 ]
 
 [project.scripts]

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -25,6 +25,9 @@ from fastapi import FastAPI, HTTPException, Request, Query
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from dotenv import load_dotenv
+
+load_dotenv()
 
 from .config import (
     DATA_DIR,


### PR DESCRIPTION
## Summary
- load variables from .env before importing configuration
- add python-dotenv dependency
- document .env support in README

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fc59e7a7c8332a7c37a5c8064074f