### PR TITLE
Load dotenv in settings utils and fix import order

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -25,10 +25,6 @@ from fastapi import FastAPI, HTTPException, Request, Query
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from dotenv import load_dotenv
-
-load_dotenv()
-
 from .config import (
     DATA_DIR,
     STATIC_DIR,

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from typing import Any, Dict
 
 import yaml
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # ``settings.yaml`` lives inside the application directory which defaults to
 # ``/app`` but can be overridden via the ``APP_DIR`` environment variable.


### PR DESCRIPTION
## Summary
- centralize .env handling inside `settings_utils` to ensure environment variables are loaded before config is imported
- reorder imports in `main.py` so application modules sit at the top of the module

## Testing
- `pylint src/echo_journal/main.py src/echo_journal/settings_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc6ddc6048332988b8fb2859e9df5