### PR TITLE
Load environment values for blank settings

### DIFF
--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -27,7 +27,14 @@ def load_settings(path: Path | None = None) -> Dict[str, str]:
         with path.open("r", encoding="utf-8") as fh:
             data: Dict[str, Any] = yaml.safe_load(fh) or {}
             # Ensure keys and values are strings
-            return {str(k): str(v) for k, v in data.items()}
+            data = {str(k): "" if v is None else str(v) for k, v in data.items()}
+            # Fill in blank values from environment variables
+            for key, value in list(data.items()):
+                if value == "":
+                    env_val = os.getenv(key)
+                    if env_val:
+                        data[key] = env_val
+            return data
     except OSError as exc:
         logger.error("Could not read %s: %s", path, exc)
         return {}

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -16,6 +16,15 @@ def test_load_settings_returns_strings(tmp_path):
     assert data == {"A": "1", "B": "test"}
 
 
+def test_load_settings_uses_env_for_blank_values(tmp_path, monkeypatch):
+    """Blank values in settings should fall back to environment variables."""
+    p = tmp_path / "settings.yaml"
+    p.write_text("A:\nB: existing\n", encoding="utf-8")
+    monkeypatch.setenv("A", "from_env")
+    data = settings_utils.load_settings(p)
+    assert data == {"A": "from_env", "B": "existing"}
+
+
 def test_save_settings_merges(tmp_path):
     """``save_settings`` should merge and persist values."""
     p = tmp_path / "settings.yaml"


### PR DESCRIPTION
## Summary
- Fill blank settings entries with values from `.env`
- Test that environment variables populate empty settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fcd94db448332808e7195d4c604c6