### PR TITLE
Align integration checkbox labels and apply accent theming

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,10 +13,10 @@
     <p class="text-center text-gray-500 dark:text-gray-400">Enable or disable optional integrations and edit server settings. Values are saved to <code>settings.yaml</code>. Changes require a restart.</p>
     <fieldset id="integration-settings" class="space-y-2 text-left">
       <legend class="sr-only">Integrations</legend>
-      <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-wordnik" class="mr-2">Wordnik word of the day</label>
-      <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-immich" class="mr-2">Immich photos</label>
-      <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-jellyfin" class="mr-2">Jellyfin media</label>
-      <label class="flex items-center gap-2 justify-center"><input type="checkbox" id="integration-fact" class="mr-2">Fact of the day</label>
+      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-wordnik" class="mr-2 accent-blue-600 dark:accent-blue-400">Wordnik word of the day</label>
+      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-immich" class="mr-2 accent-blue-600 dark:accent-blue-400">Immich photos</label>
+      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-jellyfin" class="mr-2 accent-blue-600 dark:accent-blue-400">Jellyfin media</label>
+      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-fact" class="mr-2 accent-blue-600 dark:accent-blue-400">Fact of the day</label>
     </fieldset>
     <div id="settings-fields" class="space-y-2"></div>
     <button type="button" id="save-settings" class="mx-auto block bg-blue-600 text-white px-4 py-1 rounded">Save</button>


### PR DESCRIPTION
## Summary
- Align integration settings checkboxes to the start for a consistent layout
- Add blue accent classes for light/dark theme support

## Testing
- `npm run build:css`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688fe3088474833298ed2c5caa8167a6