### PR TITLE
chore: refine settings input styling

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -134,7 +134,7 @@ document.addEventListener("DOMContentLoaded", () => {
           input.type = 'text';
           input.id = `setting-${key}`;
           input.value = value;
-          input.className = 'flex-1 border rounded px-2 py-1 bg-white dark:bg-[#333]';
+          input.className = 'flex-1 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring focus:ring-blue-500 dark:focus:ring-blue-400';
           label.appendChild(input);
           settingsFields.appendChild(label);
         });


### PR DESCRIPTION
## Summary
- refine styling of settings inputs for better light/dark mode consistency
- add focus ring classes for clearer accessibility feedback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe6c09718833295b40042ce7d4891