### PR TITLE
Improve settings page button styling

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,7 +19,7 @@
       <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-fact" class="mr-2 accent-blue-600 dark:accent-blue-400">Fact of the day</label>
     </fieldset>
     <div id="settings-fields" class="space-y-2"></div>
-    <button type="button" id="save-settings" class="mx-auto block bg-blue-600 text-white px-4 py-1 rounded">Save</button>
+    <button type="button" id="save-settings" class="mx-auto block bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white px-4 py-2 rounded font-semibold transition focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">Save</button>
   </form>
 </section>
 


### PR DESCRIPTION
## Summary
- update Save Settings button with enhanced blue hover/dark variants
- add focus ring styles for accessibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe7aa78588332b870d50bc0aaa9ff