### PR TITLE
Expose prompt anchor in UI

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -208,11 +208,13 @@ async def index(request: Request):  # pylint: disable=too-many-locals
         if not prompt and not entry:
             entry = body.strip()
         category = meta.get("category", "")
+        anchor = meta.get("anchor", "")
         wotd = meta.get("wotd", "")
         wotd_def = meta.get("wotd_def", "")
     else:
         prompt = ""
         category = ""
+        anchor = ""
         entry = ""
         wotd = ""
         wotd_def = ""
@@ -236,6 +238,7 @@ async def index(request: Request):  # pylint: disable=too-many-locals
             "request": request,
             "prompt": prompt,
             "category": category,
+            "anchor": anchor,
             "date": date_str,
             "content": entry,
             "readonly": False,  # Explicit

--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -3,6 +3,7 @@
   const entryDate = cfg.entryDate || "";
   let currentPrompt = cfg.prompt || "";
   let currentCategory = cfg.category || "";
+  let currentAnchor = cfg.anchor || "";
   const promptKey = `ej-prompt-${entryDate}`;
   const readonly = cfg.readonly === true || cfg.readonly === "true";
   const energyLevels = { drained: 1, low: 2, ok: 3, energized: 4 };
@@ -157,6 +158,7 @@
 
     const promptEl = document.getElementById('daily-prompt');
     const catEl = document.getElementById('prompt-category');
+    const anchorEl = document.getElementById('prompt-anchor');
     const textarea = document.getElementById('journal-text');
     const stored = localStorage.getItem(promptKey);
     if (stored) {
@@ -164,6 +166,7 @@
         const data = JSON.parse(stored);
         currentPrompt = data.prompt || currentPrompt;
         currentCategory = data.category || currentCategory;
+        currentAnchor = data.anchor || currentAnchor;
       } catch (_) {}
     }
     const revealPrompt = (startDelay = delay + 300) => {
@@ -185,6 +188,10 @@
       if (catEl) {
         catEl.textContent = currentCategory || '';
         catEl.classList.toggle('hidden', !currentCategory);
+      }
+      if (anchorEl) {
+        anchorEl.textContent = currentAnchor || '';
+        anchorEl.classList.toggle('hidden', !currentAnchor);
       }
     };
 
@@ -223,9 +230,10 @@
           const data = await res.json();
           currentPrompt = data.prompt;
           currentCategory = data.category || '';
+          currentAnchor = data.anchor || '';
           revealPrompt(0);
           promptShown = true;
-          localStorage.setItem(promptKey, JSON.stringify({ prompt: currentPrompt, category: currentCategory }));
+          localStorage.setItem(promptKey, JSON.stringify({ prompt: currentPrompt, category: currentCategory, anchor: currentAnchor }));
         }
       } catch (_) {}
     };
@@ -319,12 +327,17 @@
             const data = await res.json();
             currentPrompt = data.prompt;
             currentCategory = data.category || '';
+            currentAnchor = data.anchor || '';
             promptEl.textContent = currentPrompt;
             if (catEl) {
               catEl.textContent = currentCategory;
               catEl.classList.toggle('hidden', !currentCategory);
             }
-            localStorage.setItem(promptKey, JSON.stringify({ prompt: currentPrompt, category: currentCategory }));
+            if (anchorEl) {
+              anchorEl.textContent = currentAnchor;
+              anchorEl.classList.toggle('hidden', !currentAnchor);
+            }
+            localStorage.setItem(promptKey, JSON.stringify({ prompt: currentPrompt, category: currentCategory, anchor: currentAnchor }));
           }
         } catch (_) {}
       });
@@ -339,12 +352,17 @@
             const data = await res.json();
             currentPrompt = data.prompt;
             currentCategory = '';
+            currentAnchor = '';
             promptEl.textContent = currentPrompt;
             if (catEl) {
               catEl.textContent = '';
               catEl.classList.add('hidden');
             }
-            localStorage.setItem(promptKey, JSON.stringify({ prompt: currentPrompt, category: currentCategory }));
+            if (anchorEl) {
+              anchorEl.textContent = '';
+              anchorEl.classList.add('hidden');
+            }
+            localStorage.setItem(promptKey, JSON.stringify({ prompt: currentPrompt, category: currentCategory, anchor: currentAnchor }));
           } else {
             alert('Failed to fetch AI prompt.');
           }

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -60,6 +60,7 @@
         {% else %}
         <p id="prompt-category" class="italic hidden"></p>
         {% endif %}
+        <p id="prompt-anchor" class="italic hidden">{{ anchor }}</p>
         <p id="intro-tagline" class="text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide">Echo Journal is <strong>your</strong> space. Let the words come naturally.</p>
       </details>
     </div>
@@ -100,6 +101,7 @@
         entryDate: "{{ date }}",
         prompt: {{ prompt | tojson }},
         category: {{ category | tojson }},
+        anchor: {{ anchor | tojson }},
         readonly: {{ 'true' if readonly else 'false' }},
         integrations: {{ integrations | tojson }} {# includes ai integration key #}
       };


### PR DESCRIPTION
## Summary
- Pass prompt `anchor` from backend into template configuration
- Display anchor text alongside category in prompt details
- Update client script to persist, show, and refresh anchors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ff76388b48332beaa1a5fa6eda8f2