### PR TITLE
feat: improve integration settings layout

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -14,11 +14,13 @@
   <form id="settings-form" class="w-full text-sm space-y-4">
     <p class="text-center text-gray-500 dark:text-gray-400">Enable or disable optional integrations and edit server settings. Values are saved to <code>settings.yaml</code>. Changes require a restart.</p>
     <fieldset id="integration-settings" class="space-y-2 text-left">
-      <legend class="sr-only">Integrations</legend>
-      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-wordnik" class="mr-2 accent-blue-600 dark:accent-blue-400">Wordnik word of the day</label>
-      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-immich" class="mr-2 accent-blue-600 dark:accent-blue-400">Immich photos</label>
-      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-jellyfin" class="mr-2 accent-blue-600 dark:accent-blue-400">Jellyfin media</label>
-      <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-fact" class="mr-2 accent-blue-600 dark:accent-blue-400">Fact of the day</label>
+      <legend class="font-semibold text-lg">Integrations</legend>
+      <div class="grid gap-2 sm:grid-cols-2">
+        <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-wordnik" class="mr-2 accent-blue-600 dark:accent-blue-400">Wordnik word of the day</label>
+        <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-immich" class="mr-2 accent-blue-600 dark:accent-blue-400">Immich photos</label>
+        <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-jellyfin" class="mr-2 accent-blue-600 dark:accent-blue-400">Jellyfin media</label>
+        <label class="flex items-center gap-2 justify-start"><input type="checkbox" id="integration-fact" class="mr-2 accent-blue-600 dark:accent-blue-400">Fact of the day</label>
+      </div>
     </fieldset>
     <div id="settings-fields" class="space-y-4"></div>
     <button type="button" id="save-settings" class="mx-auto block bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white px-4 py-2 rounded font-semibold transition focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400">Save</button>


### PR DESCRIPTION
## Summary
- show a visible legend heading for integration settings
- place integration checkboxes in a responsive grid for clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890820463888332bb6175d7d3246fed