### PR TITLE
Animate restart notice when no entry for today

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -130,6 +130,7 @@
     const focusToggle = document.getElementById('focus-toggle');
     const newBtn = document.getElementById('new-prompt');
     const aiBtn = document.getElementById('ai-prompt');
+    const restartNotice = document.getElementById('restart-notice');
     if (aiBtn && !integrationSettings.ai) {
       aiBtn.classList.add('hidden');
     }
@@ -139,6 +140,19 @@
     const energySelect = document.getElementById('energy-select');
     let moodEnergyLocked = false;
     let delay = 0;
+    if (restartNotice) {
+      const removeNotice = () => restartNotice.remove();
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        restartNotice.classList.remove('opacity-0');
+        setTimeout(removeNotice, 5000);
+      } else {
+        requestAnimationFrame(() => restartNotice.classList.remove('opacity-0'));
+        setTimeout(() => {
+          restartNotice.classList.add('opacity-0');
+          setTimeout(removeNotice, 1000);
+        }, 4000);
+      }
+    }
     if (welcomeEl) {
       const wantsGreeting = welcomeEl.dataset.dynamicGreeting === 'true';
 

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -16,8 +16,8 @@
 {% block main_classes %}prose dark:prose-invert w-full max-w-md md:max-w-2xl lg:max-w-5xl xl:max-w-6xl mx-auto space-y-3 bg-gray-100 dark:bg-[#222] text-gray-800 dark:text-gray-100{% endblock %}
 
 {% block content %}
-{% if missing_yesterday %}
-<section id="restart-notice" class="mt-4 w-full text-center text-sm text-gray-600 dark:text-gray-300">
+{% if missing_yesterday and not content %}
+<section id="restart-notice" class="mt-4 w-full text-center text-lg text-gray-600 dark:text-gray-300 opacity-0 transition-opacity duration-1000">
   Looks like there's no entry for yesterday. Restart from today?
 </section>
 {% endif %}


### PR DESCRIPTION
## Summary
- Show the restart streak notice only when yesterday is missing **and** today's entry is empty
- Enlarge and animate the restart notice so it briefly fades in then out

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890823fd8dc83329d9cc5a8b2050a82