### PR TITLE
Align settings form inputs

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -236,14 +236,14 @@ document.addEventListener("DOMContentLoaded", () => {
           legend.className = 'font-semibold';
           fieldset.appendChild(legend);
           const grid = document.createElement('div');
-          grid.className = 'grid gap-2 md:grid-cols-2';
+          grid.className = 'space-y-2';
           keys.forEach((key) => {
             const info = envKeyInfo[key] || {};
             const labelText = info.label || key;
             const wrapper = document.createElement('div');
             wrapper.className = 'space-y-1';
             const label = document.createElement('label');
-            label.className = 'flex items-center gap-2 justify-between';
+            label.className = 'flex items-center justify-between gap-2';
             const span = document.createElement('span');
             span.textContent = labelText;
             label.appendChild(span);
@@ -251,7 +251,7 @@ document.addEventListener("DOMContentLoaded", () => {
             input.type = 'text';
             input.id = `setting-${key}`;
             input.value = settings[key];
-            input.className = 'flex-1 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring focus:ring-blue-500 dark:focus:ring-blue-400';
+            input.className = 'ml-auto w-64 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring focus:ring-blue-500 dark:focus:ring-blue-400';
             label.appendChild(input);
             wrapper.appendChild(label);
             if (info.help) {


### PR DESCRIPTION
## Summary
- ensure settings form fields are single-column with labels on the left and text inputs on the right

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68908847c6108332ab00061c77c39736