### PR TITLE
style: enhance restart streak nudge

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -144,13 +144,13 @@
       const removeNotice = () => restartNotice.remove();
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
         restartNotice.classList.remove('opacity-0');
-        setTimeout(removeNotice, 5000);
+        setTimeout(removeNotice, 7000);
       } else {
         requestAnimationFrame(() => restartNotice.classList.remove('opacity-0'));
         setTimeout(() => {
           restartNotice.classList.add('opacity-0');
           setTimeout(removeNotice, 1000);
-        }, 4000);
+        }, 6000);
       }
     }
     if (welcomeEl) {

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -17,7 +17,7 @@
 
 {% block content %}
 {% if missing_yesterday and not content %}
-<section id="restart-notice" class="mt-4 w-full text-center text-lg text-gray-600 dark:text-gray-300 opacity-0 transition-opacity duration-1000">
+<section id="restart-notice" class="meta-card mt-4 w-full max-w-md mx-auto text-center text-xl font-semibold text-gray-700 dark:text-gray-200 opacity-0 transition-opacity duration-1000">
   Looks like there's no entry for yesterday. Restart from today?
 </section>
 {% endif %}


### PR DESCRIPTION
## Summary
- Improve restart notice styling with larger, bold text in a meta card.
- Keep restart streak nudge visible longer before fading.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689088b8b2e88332a12d7807b8568fe1