### PR TITLE
refactor: route logs and metadata to dedicated folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ is the authoritative source for these values:
 | `JELLYFIN_PLAY_THRESHOLD` | Percent threshold for "played". | Default `90`. |
 | `NOMINATIM_USER_AGENT` | Identifies your app when calling the Nominatim reverse geocoding API. | Include contact info per the usage policy. |
 | `LOG_LEVEL` | Logging verbosity. | Default `DEBUG`. |
-| `LOG_FILE` | Path to log file. | If empty, logs to stderr. |
+| `LOG_FILE` | Path to log file. | Default `/journals/.log/echo_journal.log`; if empty, logs to stderr. |
 | `LOG_MAX_BYTES` | Max size before log rotation. | Default `1,048,576`. |
 | `LOG_BACKUP_COUNT` | Number of rotated log files. | Default `3`. |
 | `BASIC_AUTH_USERNAME` | Username for optional HTTP Basic authentication. | |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,7 +86,7 @@
   - Auto-save on blur or idle timeout (optional)
 - **Full ambient metadata capture**
   - Mood, time block, weather, Jellyfin/Last.fm/Immich content
-  - Files created: `.songs.json`, `.media.json`, `.photos.json`, `.meta.json`
+  - Files created under `.meta/`: `<date>.songs.json`, `<date>.media.json`, `<date>.photos.json`, `<date>.meta.json`
   - Example YAML frontmatter:
     ```yaml
     mood: Energized

--- a/src/echo_journal/config.py
+++ b/src/echo_journal/config.py
@@ -31,9 +31,11 @@ NOMINATIM_USER_AGENT = _get_setting(
     "NOMINATIM_USER_AGENT", "EchoJournal/1.0 (contact@example.com)"
 )
 
-# File logging path - defaults to ``DATA_DIR/echo_journal.log`` but can
+# File logging path - defaults to ``DATA_DIR/.log/echo_journal.log`` but can
 # be overridden via the ``LOG_FILE`` environment variable.
-LOG_FILE = Path(_get_setting("LOG_FILE", str(DATA_DIR / "echo_journal.log")))
+LOG_FILE = Path(
+    _get_setting("LOG_FILE", str(DATA_DIR / ".log" / "echo_journal.log"))
+)
 
 # Log level for the application. Defaults to ``DEBUG`` so development
 # environments capture detailed output, but can be overridden to

--- a/src/echo_journal/immich_utils.py
+++ b/src/echo_journal/immich_utils.py
@@ -112,8 +112,10 @@ async def update_photo_metadata(date_str: str, journal_path: Path) -> None:
             }
         )
 
-    photo_path = journal_path.with_suffix(".photos.json")
+    meta_dir = journal_path.parent / ".meta"
     try:
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        photo_path = meta_dir / f"{journal_path.stem}.photos.json"
         with open(photo_path, "w", encoding="utf-8") as f:
             json.dump(photo_metadata, f, indent=2)
         logger.info("Wrote %d photo records to %s", len(photo_metadata), photo_path)

--- a/src/echo_journal/jellyfin_utils.py
+++ b/src/echo_journal/jellyfin_utils.py
@@ -162,8 +162,10 @@ async def update_song_metadata(date_str: str, journal_path: Path) -> None:
         logger.info("No song data for %s", date_str)
         return
 
-    song_path = journal_path.with_suffix(".songs.json")
+    meta_dir = journal_path.parent / ".meta"
     try:
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        song_path = meta_dir / f"{journal_path.stem}.songs.json"
         with open(song_path, "w", encoding="utf-8") as f:
             json.dump(songs, f, indent=2)
         logger.info("Wrote %d song records to %s", len(songs), song_path)
@@ -224,8 +226,10 @@ async def update_media_metadata(date_str: str, journal_path: Path) -> None:
         logger.info("No media data for %s", date_str)
         return
 
-    media_path = journal_path.with_suffix(".media.json")
+    meta_dir = journal_path.parent / ".meta"
     try:
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        media_path = meta_dir / f"{journal_path.stem}.media.json"
         with open(media_path, "w", encoding="utf-8") as f:
             json.dump(media, f, indent=2)
         logger.info("Wrote %d media records to %s", len(media), media_path)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -464,7 +464,8 @@ def test_archive_filter_has_photos(test_client):
     """Entries can be filtered by those containing photos."""
     md1 = main.DATA_DIR / "2024-01-01.md"
     md1.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
-    photos_path = main.DATA_DIR / "2024-01-01.photos.json"
+    photos_path = main.DATA_DIR / ".meta" / "2024-01-01.photos.json"
+    photos_path.parent.mkdir(exist_ok=True)
     photos_path.write_text(json.dumps([{"url": "u", "thumb": "t"}]), encoding="utf-8")
 
     md2 = main.DATA_DIR / "2024-01-02.md"
@@ -560,7 +561,7 @@ def test_save_entry_adds_photo_metadata(test_client, monkeypatch):
     payload = {"date": "2023-01-01", "content": "entry", "prompt": "prompt"}
     resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    json_path = main.DATA_DIR / "2023-01-01.photos.json"
+    json_path = main.DATA_DIR / ".meta" / "2023-01-01.photos.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))
     assert data[0]["caption"] == "img1.jpg"
@@ -590,7 +591,7 @@ def test_immich_disabled_skips_photo_metadata(test_client, monkeypatch):
     }
     resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    json_path = main.DATA_DIR / "2023-01-02.photos.json"
+    json_path = main.DATA_DIR / ".meta" / "2023-01-02.photos.json"
     assert not json_path.exists()
 
 
@@ -607,7 +608,7 @@ def test_save_entry_adds_song_metadata(test_client, monkeypatch):
     payload = {"date": "2023-05-05", "content": "entry", "prompt": "prompt"}
     resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    json_path = main.DATA_DIR / "2023-05-05.songs.json"
+    json_path = main.DATA_DIR / ".meta" / "2023-05-05.songs.json"
     assert json_path.exists()
     songs = json.loads(json_path.read_text(encoding="utf-8"))
     assert songs[0]["track"] == "t1"
@@ -625,7 +626,7 @@ def test_save_entry_adds_media_metadata(test_client, monkeypatch):
     payload = {"date": "2023-05-06", "content": "entry", "prompt": "prompt"}
     resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    json_path = main.DATA_DIR / "2023-05-06.media.json"
+    json_path = main.DATA_DIR / ".meta" / "2023-05-06.media.json"
     assert json_path.exists()
     media = json.loads(json_path.read_text(encoding="utf-8"))
     assert media[0]["title"] == "Movie"
@@ -650,8 +651,8 @@ def test_jellyfin_disabled_skips_metadata(test_client, monkeypatch):
     }
     resp = test_client.post("/entry", json=payload)
     assert resp.status_code == 200
-    songs_path = main.DATA_DIR / "2023-05-07.songs.json"
-    media_path = main.DATA_DIR / "2023-05-07.media.json"
+    songs_path = main.DATA_DIR / ".meta" / "2023-05-07.songs.json"
+    media_path = main.DATA_DIR / ".meta" / "2023-05-07.media.json"
     assert not songs_path.exists()
     assert not media_path.exists()
 
@@ -672,7 +673,7 @@ def test_backfill_song_metadata(test_client, monkeypatch):
 
     assert resp.status_code == 200
     assert resp.json()["added"] == 1
-    songs_path = main.DATA_DIR / "2023-06-06.songs.json"
+    songs_path = main.DATA_DIR / ".meta" / "2023-06-06.songs.json"
     assert songs_path.exists()
 
 
@@ -732,7 +733,8 @@ def test_view_entry_shows_photos(test_client):
             "caption": "two",
         },
     ]
-    json_path = main.DATA_DIR / "2023-04-04.photos.json"
+    json_path = main.DATA_DIR / ".meta" / "2023-04-04.photos.json"
+    json_path.parent.mkdir(exist_ok=True)
     json_path.write_text(json.dumps(photos), encoding="utf-8")
 
     resp = test_client.get("/archive/2023-04-04")
@@ -750,7 +752,8 @@ def test_view_entry_shows_songs(test_client):
         {"track": "s1", "artist": "a1", "plays": 2},
         {"track": "s2", "artist": "a2", "plays": 1},
     ]
-    json_path = main.DATA_DIR / "2023-07-07.songs.json"
+    json_path = main.DATA_DIR / ".meta" / "2023-07-07.songs.json"
+    json_path.parent.mkdir(exist_ok=True)
     json_path.write_text(json.dumps(songs), encoding="utf-8")
 
     resp = test_client.get("/archive/2023-07-07")
@@ -764,7 +767,8 @@ def test_archive_shows_song_icon(test_client):
 
     md_path = main.DATA_DIR / "2024-02-02.md"
     md_path.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
-    json_path = main.DATA_DIR / "2024-02-02.songs.json"
+    json_path = main.DATA_DIR / ".meta" / "2024-02-02.songs.json"
+    json_path.parent.mkdir(exist_ok=True)
     json_path.write_text(json.dumps([{"track": "t", "artist": "a"}]), encoding="utf-8")
 
     resp = test_client.get("/archive")
@@ -777,7 +781,8 @@ def test_archive_filter_has_songs(test_client):
 
     md1 = main.DATA_DIR / "2025-01-01.md"
     md1.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
-    songs_path = main.DATA_DIR / "2025-01-01.songs.json"
+    songs_path = main.DATA_DIR / ".meta" / "2025-01-01.songs.json"
+    songs_path.parent.mkdir(exist_ok=True)
     songs_path.write_text(json.dumps([{"track": "t", "artist": "a"}]), encoding="utf-8")
 
     md2 = main.DATA_DIR / "2025-01-02.md"
@@ -794,12 +799,14 @@ def test_archive_sort_by_songs(test_client):
 
     md1 = main.DATA_DIR / "2026-01-01.md"
     md1.write_text("# Prompt\nP1\n\n# Entry\nE1", encoding="utf-8")
-    path1 = main.DATA_DIR / "2026-01-01.songs.json"
+    path1 = main.DATA_DIR / ".meta" / "2026-01-01.songs.json"
+    path1.parent.mkdir(exist_ok=True)
     path1.write_text(json.dumps([{"track": "b"}]), encoding="utf-8")
 
     md2 = main.DATA_DIR / "2026-01-02.md"
     md2.write_text("# Prompt\nP2\n\n# Entry\nE2", encoding="utf-8")
-    path2 = main.DATA_DIR / "2026-01-02.songs.json"
+    path2 = main.DATA_DIR / ".meta" / "2026-01-02.songs.json"
+    path2.parent.mkdir(exist_ok=True)
     path2.write_text(json.dumps([{"track": "a"}]), encoding="utf-8")
 
     resp = test_client.get("/archive", params={"sort_by": "songs"})
@@ -816,7 +823,8 @@ def test_view_entry_shows_media(test_client):
         {"title": "Ep1", "series": "Show"},
         {"title": "Movie", "series": ""},
     ]
-    json_path = main.DATA_DIR / "2027-01-01.media.json"
+    json_path = main.DATA_DIR / ".meta" / "2027-01-01.media.json"
+    json_path.parent.mkdir(exist_ok=True)
     json_path.write_text(json.dumps(media_items), encoding="utf-8")
 
     resp = test_client.get("/archive/2027-01-01")
@@ -830,7 +838,8 @@ def test_archive_filter_has_media(test_client):
 
     md1 = main.DATA_DIR / "2028-01-01.md"
     md1.write_text("# Prompt\nP\n\n# Entry\nE", encoding="utf-8")
-    media_path = main.DATA_DIR / "2028-01-01.media.json"
+    media_path = main.DATA_DIR / ".meta" / "2028-01-01.media.json"
+    media_path.parent.mkdir(exist_ok=True)
     media_path.write_text(json.dumps([{"title": "M"}]), encoding="utf-8")
 
     md2 = main.DATA_DIR / "2028-01-02.md"

--- a/tests/test_immich_utils.py
+++ b/tests/test_immich_utils.py
@@ -87,7 +87,7 @@ def test_update_photo_metadata_filters_assets(monkeypatch, tmp_path):
 
     asyncio.run(immich_utils.update_photo_metadata("2025-07-19", md_path))
 
-    json_path = md_path.with_suffix(".photos.json")
+    json_path = md_path.parent / ".meta" / f"{md_path.stem}.photos.json"
     data = jsonlib.loads(json_path.read_text(encoding="utf-8"))
 
     assert len(data) == 1


### PR DESCRIPTION
## Summary
- default log file now stored under a new `.log` directory and logger ensures its creation
- journal metadata JSON files (.photos, .songs, .media) written and loaded from a `.meta` directory
- updated docs and tests for new folder structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689089bd72848332ac8559c9f49e5d7d