### PR TITLE
Disable settings save button during request

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -267,7 +267,12 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       });
 
-    settingsForm.querySelector('#save-settings').addEventListener('click', async () => {
+    const saveBtn = settingsForm.querySelector('#save-settings');
+    saveBtn.addEventListener('click', async () => {
+      const originalText = saveBtn.textContent;
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving...';
+
       const updated = {};
       settingsFields.querySelectorAll('input').forEach((input) => {
         const k = input.id.replace('setting-', '');
@@ -279,11 +284,18 @@ document.addEventListener("DOMContentLoaded", () => {
         updated[settingKey] = cb && cb.checked ? 'true' : 'false';
       });
 
-      await fetch('/api/settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updated),
-      });
+      try {
+        await fetch('/api/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(updated),
+        });
+      } catch (err) {
+        console.error('Failed to save settings', err);
+      } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = originalText;
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary
- Improve UX by disabling "Save" button on settings page while request is in-flight
- Swap button label to "Saving..." and restore after request completes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890928b69508332b5408d0638a55370