### PR TITLE
Respect reduced motion on settings page

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -75,8 +75,13 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   const welcomeEl = document.getElementById("welcome-message");
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   if (welcomeEl) {
-    animateText(welcomeEl, 0, 60, 200);
+    if (prefersReducedMotion) {
+      welcomeEl.classList.remove('opacity-0');
+    } else {
+      animateText(welcomeEl, 0, 60, 200);
+    }
   }
 
     const settingsForm = document.getElementById('settings-form');


### PR DESCRIPTION
## Summary
- Skip title animation when `prefers-reduced-motion` is enabled

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689094b44b748332bf6354ce0bc930df