### PR TITLE
Style settings categories as cards

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -236,7 +236,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         Object.entries(envSettingCategories).forEach(([category, keys]) => {
           const details = document.createElement('details');
-          details.className = 'space-y-2 text-left';
+          details.className = 'paper-card space-y-2 text-left';
           details.open = true;
           const summary = document.createElement('summary');
           summary.textContent = category;


### PR DESCRIPTION
## Summary
- apply paper-card styling to dynamically generated settings groups

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689099bd82908332adedd7d0eb37dab3