### PR TITLE
Reload config after saving settings

### DIFF
--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -52,4 +52,13 @@ def save_settings(values: Dict[str, str], path: Path | None = None) -> Dict[str,
             yaml.safe_dump(data, fh, allow_unicode=True, default_flow_style=False)
     except OSError as exc:
         logger.error("Could not write %s: %s", path, exc)
+    else:
+        if path == SETTINGS_PATH:
+            try:
+                import importlib
+                from . import config as config_module
+
+                importlib.reload(config_module)
+            except Exception as exc:  # pragma: no cover - unexpected
+                logger.error("Could not reload config: %s", exc)
     return data

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -65,3 +65,22 @@ def test_settings_path_relative_to_data_dir(tmp_path, monkeypatch):
     # Reset module to default state for other tests
     monkeypatch.delenv("DATA_DIR")
     importlib.reload(settings_utils)
+
+
+def test_save_settings_reloads_config(tmp_path, monkeypatch):
+    """Saving to the default path should reload the configuration module."""
+    settings_file = tmp_path / "settings.yaml"
+    orig_path = settings_utils.SETTINGS_PATH
+    monkeypatch.setattr(settings_utils, "SETTINGS_PATH", settings_file)
+
+    from echo_journal import config
+
+    importlib.reload(config)
+    assert config.WORDNIK_API_KEY is None
+
+    settings_utils.save_settings({"WORDNIK_API_KEY": "abc"})
+    assert config.WORDNIK_API_KEY == "abc"
+
+    # Reset modules for subsequent tests
+    monkeypatch.setattr(settings_utils, "SETTINGS_PATH", orig_path)
+    importlib.reload(config)


### PR DESCRIPTION
## Summary
- reload configuration automatically when settings.yaml is updated
- cover settings reload in tests

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68909fb97d8883329cdde80c4c19c7e1