### PR TITLE
docs: add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ echo-journal
 
 Then open <http://localhost:8000> in your browser. You should see the Echo Journal interface and can create a test entry.
 
+## Testing
+
+Run the test suite to verify your setup:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+npm install
+npm run build:css
+pytest
+```
+
+The npm steps are required the first time or whenever dependencies change.
+
 ## Roadmap
 
 Echo Journal's development roadmap is maintained in [ROADMAP.md](ROADMAP.md). Highlights:


### PR DESCRIPTION
## Summary
- document how to set up a virtual environment and run the test suite
- note required npm steps before running tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68909ff7fbe08332890811d2c96ab0c5