### PR TITLE
Fix Pylint violations across utilities and tests

### DIFF
--- a/src/echo_journal/prompt_utils.py
+++ b/src/echo_journal/prompt_utils.py
@@ -1,12 +1,12 @@
 """Prompt loading and generation helpers."""
 
 import asyncio
+import logging
 import random
 from datetime import date
 
-import yaml
 import aiofiles
-import logging
+import yaml
 
 from .config import PROMPTS_FILE, ENCODING
 
@@ -26,9 +26,17 @@ def _choose_anchor(mood: str | None, energy: int | None) -> str | None:
     anchors: list[str] = []
 
     if energy == 1:
-        anchors = ["micro"] if mood_l in {"drained", "self-doubt", "sad"} else ["micro", "soft"]
+        anchors = (
+            ["micro"] if mood_l in {"drained", "self-doubt", "sad"} else ["micro", "soft"]
+        )
         anchor = random.choice(anchors)
-        logger.debug("Selected anchor '%s' for mood=%s energy=%s from %s", anchor, mood_l, energy, anchors)
+        logger.debug(
+            "Selected anchor '%s' for mood=%s energy=%s from %s",
+            anchor,
+            mood_l,
+            energy,
+            anchors,
+        )
         return anchor
 
     if energy == 2:
@@ -56,7 +64,13 @@ def _choose_anchor(mood: str | None, energy: int | None) -> str | None:
         return None
 
     anchor = random.choice(anchors)
-    logger.debug("Selected anchor '%s' for mood=%s energy=%s from %s", anchor, mood_l, energy, anchors)
+    logger.debug(
+        "Selected anchor '%s' for mood=%s energy=%s from %s",
+        anchor,
+        mood_l,
+        energy,
+        anchors,
+    )
     return anchor
 
 

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -1,5 +1,6 @@
 """Helpers for reading and writing ``settings.yaml`` files."""
 
+import importlib
 import logging
 import os
 from pathlib import Path
@@ -55,10 +56,8 @@ def save_settings(values: Dict[str, str], path: Path | None = None) -> Dict[str,
     else:
         if path == SETTINGS_PATH:
             try:
-                import importlib
-                from . import config as config_module
-
+                config_module = importlib.import_module("echo_journal.config")
                 importlib.reload(config_module)
-            except Exception as exc:  # pragma: no cover - unexpected
+            except ImportError as exc:  # pragma: no cover - unexpected
                 logger.error("Could not reload config: %s", exc)
     return data

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -5,7 +5,7 @@ import logging
 
 import yaml
 
-from echo_journal import settings_utils
+from echo_journal import config, settings_utils
 
 
 def test_load_settings_returns_strings(tmp_path):
@@ -72,8 +72,6 @@ def test_save_settings_reloads_config(tmp_path, monkeypatch):
     settings_file = tmp_path / "settings.yaml"
     orig_path = settings_utils.SETTINGS_PATH
     monkeypatch.setattr(settings_utils, "SETTINGS_PATH", settings_file)
-
-    from echo_journal import config
 
     importlib.reload(config)
     assert config.WORDNIK_API_KEY is None


### PR DESCRIPTION
## Summary
- reorder imports and wrap long log messages in prompt utilities
- reload configuration safely without cyclic imports
- tidy settings tests to import config at module scope

## Testing
- `pylint src/echo_journal/prompt_utils.py src/echo_journal/settings_utils.py tests/test_settings_utils.py tests/test_wordnik_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890a42b6c4c8332846f3c2029dd1f99