### PR TITLE
Warn when settings file missing and document location

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,12 @@ This allows the backend to score prompts based on numeric intensity.
 Echo Journal automatically loads variables from a `.env` file at startup using
 [`python-dotenv`](https://pypi.org/project/python-dotenv/).
 
-The `settings.yaml` file configures optional integrations and runtime paths. It
-is the authoritative source for these values:
+On startup the application looks for a `settings.yaml` file in
+`<DATA_DIR>/settings.yaml` (default `/journals/settings.yaml`). If it is
+missing a warning is logged noting the expected path and the app falls back to
+environment variables. The `settings.yaml` file configures optional
+integrations and runtime paths. It is the authoritative source for these
+values:
 
 | Variable | Purpose | Notes / Defaults |
 | --- | --- | --- |

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -40,6 +40,9 @@ def load_settings(path: Path | None = None) -> Dict[str, str]:
             # ``config._get_setting``.
             data = {str(k): "" if v is None else str(v) for k, v in data.items()}
             return data
+    except FileNotFoundError:
+        logger.warning("No settings file found at %s; using environment variables only", path)
+        return {}
     except OSError as exc:
         logger.error("Could not read %s: %s", path, exc)
         return {}

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -36,10 +36,10 @@ def test_save_settings_merges(tmp_path):
     assert yaml.safe_load(p.read_text(encoding="utf-8")) == {"A": "a", "B": "b"}
 
 
-def test_load_settings_logs_error(tmp_path, caplog):
-    """Missing files should log an error and return an empty dict."""
+def test_load_settings_logs_missing_warning(tmp_path, caplog):
+    """Missing files should log a warning with the expected path."""
     p = tmp_path / "missing.yaml"
-    with caplog.at_level(logging.ERROR, logger="ej.settings"):
+    with caplog.at_level(logging.WARNING, logger="ej.settings"):
         data = settings_utils.load_settings(p)
     assert data == {}
     assert any(str(p) in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- log a warning when `settings.yaml` is not found, stating the expected path
- document the default settings file location and behavior when it is missing
- update test to validate warning

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890cb3dc154833288ad3c63c12f563e