### PR TITLE
Fix settings page integration toggle

### DIFF
--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -42,8 +42,15 @@ def load_settings(path: Path | None = None) -> Dict[str, str]:
             # strings without injecting environment values here.  Any missing
             # keys will continue to fall back to ``os.getenv`` in
             # ``config._get_setting``.
-            data = {str(k): "" if v is None else str(v) for k, v in data.items()}
-            return data
+            cleaned: Dict[str, str] = {}
+            for k, v in data.items():
+                if v is None:
+                    cleaned[str(k)] = ""
+                elif isinstance(v, bool):
+                    cleaned[str(k)] = "true" if v else "false"
+                else:
+                    cleaned[str(k)] = str(v)
+            return cleaned
     except FileNotFoundError:
         if (
             path == SETTINGS_PATH
@@ -52,8 +59,15 @@ def load_settings(path: Path | None = None) -> Dict[str, str]:
         ):
             with (APP_DIR / "settings.yaml").open("r", encoding="utf-8") as fh:
                 data = yaml.safe_load(fh) or {}
-                data = {str(k): "" if v is None else str(v) for k, v in data.items()}
-                return data
+                cleaned: Dict[str, str] = {}
+                for k, v in data.items():
+                    if v is None:
+                        cleaned[str(k)] = ""
+                    elif isinstance(v, bool):
+                        cleaned[str(k)] = "true" if v else "false"
+                    else:
+                        cleaned[str(k)] = str(v)
+                return cleaned
         logger.warning(
             "No settings file found at %s; using environment variables only", path
         )

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -330,7 +330,7 @@ document.addEventListener("DOMContentLoaded", () => {
         Object.entries(integrationKeys).forEach(([key, settingKey]) => {
           const cb = document.getElementById(`integration-${key}`);
           if (cb) {
-            cb.checked = settings[settingKey] !== 'false';
+            cb.checked = String(settings[settingKey]).toLowerCase() !== 'false';
             delete settings[settingKey];
           }
         });

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -16,6 +16,14 @@ def test_load_settings_returns_strings(tmp_path):
     assert data == {"A": "1", "B": "test"}
 
 
+def test_load_settings_normalizes_boolean_values(tmp_path):
+    """Boolean values should be returned as lowercase strings."""
+    p = tmp_path / "settings.yaml"
+    p.write_text("A: true\nB: False\n", encoding="utf-8")
+    data = settings_utils.load_settings(p)
+    assert data == {"A": "true", "B": "false"}
+
+
 def test_load_settings_prefers_file_over_env_for_blank_values(tmp_path, monkeypatch):
     """Blank values in settings should override environment variables."""
     p = tmp_path / "settings.yaml"


### PR DESCRIPTION
## Summary
- normalize boolean values when loading settings.yaml
- set integration checkboxes with case-insensitive string checks
- test settings boolean normalization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890dde8b8788332ba055a164ab7d035