### PR TITLE
Fix log file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ values:
 | `JELLYFIN_PLAY_THRESHOLD` | Percent threshold for "played". | Default `90`. |
 | `NOMINATIM_USER_AGENT` | Identifies your app when calling the Nominatim reverse geocoding API. | Include contact info per the usage policy. |
 | `LOG_LEVEL` | Logging verbosity. | Default `DEBUG`. |
-| `LOG_FILE` | Path to log file. | Default `/journals/.log/echo_journal.log`; if empty, logs to stderr. |
+| `LOG_FILE` | Path to log file. | Default `/journals/.logs/echo_journal.log`; if empty, logs to stderr. |
 | `LOG_MAX_BYTES` | Max size before log rotation. | Default `1,048,576`. |
 | `LOG_BACKUP_COUNT` | Number of rotated log files. | Default `3`. |
 | `BASIC_AUTH_USERNAME` | Username for optional HTTP Basic authentication. | |

--- a/src/echo_journal/config.py
+++ b/src/echo_journal/config.py
@@ -31,10 +31,10 @@ NOMINATIM_USER_AGENT = _get_setting(
     "NOMINATIM_USER_AGENT", "EchoJournal/1.0 (contact@example.com)"
 )
 
-# File logging path - defaults to ``DATA_DIR/.log/echo_journal.log`` but can
+# File logging path - defaults to ``DATA_DIR/.logs/echo_journal.log`` but can
 # be overridden via the ``LOG_FILE`` environment variable.
 LOG_FILE = Path(
-    _get_setting("LOG_FILE", str(DATA_DIR / ".log" / "echo_journal.log"))
+    _get_setting("LOG_FILE", str(DATA_DIR / ".logs" / "echo_journal.log"))
 )
 
 # Log level for the application. Defaults to ``DEBUG`` so development


### PR DESCRIPTION
## Summary
- save logs to `.logs` instead of `.log`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68910fc988588332950c2a29e3287472