### PR TITLE
Remove unused JOURNALS_DIR setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # Example environment variables for local development
 # Copy to .env and adjust values as needed
-JOURNALS_DIR=/path/to/journals
 DATA_DIR=/journals
 APP_DIR=/app
 PROMPTS_FILE=/app/prompts.yaml

--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -379,16 +379,10 @@ The following issues were identified and subsequently resolved.
      【F:main.py†L278-L296】
 
 42. **`JOURNALS_DIR` docs mismatch code** (fixed)
-   - README now clarifies that `DATA_DIR` controls the in-container path while
-     `JOURNALS_DIR` only affects the Docker volume mount.
-   - Fixed lines:
-     ```markdown
-     When using Docker Compose, set the `JOURNALS_DIR` environment variable
-     ...
-     If you run the application without Docker, or need to override the
-     location inside the container, set the `DATA_DIR` environment variable
-     ```
-     【F:README.md†L50-L60】
+  - Docs no longer treat `JOURNALS_DIR` as a runtime setting. It only affects
+    the Docker volume mount.
+  - When using Docker Compose, set `JOURNALS_DIR` to choose the host path
+    mounted at `/journals`.
 
 43. **Double `.md` extension possible** (fixed)
    - `safe_entry_path` now uses `with_suffix` so existing `.md` extensions are

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Python dependencies are defined in `pyproject.toml` and installed with `pip inst
    npm run build:css
    ```
 
-2. Copy the example environment file and set `JOURNALS_DIR` and any other needed variables:
+2. Copy the example environment file and adjust variables if needed:
 
    ```bash
    cp .env.example .env
-   # edit .env to point JOURNALS_DIR to a writable path; it will be loaded on startup
+   # edit .env to adjust paths or API keys as needed
    ```
 
 3. Start the development server:
@@ -76,7 +76,7 @@ Python dependencies are defined in `pyproject.toml` and installed with `pip inst
 
 ```bash
 cp .env.example .env
-# adjust JOURNALS_DIR and other variables in .env
+# adjust variables in .env; optional JOURNALS_DIR controls the host path for journals
 docker-compose up --build
 ```
 
@@ -91,7 +91,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install .  # installs Echo Journal and its Python dependencies
 npm install
 npm run build:css
-cp .env.example .env  # set JOURNALS_DIR inside
+cp .env.example .env
 uvicorn echo_journal.main:app --reload
 # or
 echo-journal
@@ -129,14 +129,14 @@ dedicated API guide.*
   curl http://localhost:8000/api/settings
   ```
   ```json
-  {"JOURNALS_DIR": "/journals", "OPENAI_API_KEY": null, ...}
+  {"DATA_DIR": "/journals", "OPENAI_API_KEY": null, ...}
   ```
 
 - `POST /api/settings` – update settings and persist them to `settings.yaml`.
   ```bash
   curl -X POST http://localhost:8000/api/settings \
        -H 'Content-Type: application/json' \
-       -d '{"JOURNALS_DIR": "/journals"}'
+       -d '{"DATA_DIR": "/journals"}'
   ```
   ```json
   {"status": "ok"}
@@ -248,7 +248,6 @@ values:
 
 | Variable | Purpose | Notes / Defaults |
 | --- | --- | --- |
-| `JOURNALS_DIR` | Host directory for your Markdown entries. | Set to a writable path. |
 | `DATA_DIR` | Internal application path. | Default `/journals`. |
 | `APP_DIR` | Internal application directory. | Default `/app`. |
 | `PROMPTS_FILE` | Location of YAML prompts file. | Default `/app/prompts.yaml`. |

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -85,7 +85,6 @@ elif BASIC_AUTH_USERNAME or BASIC_AUTH_PASSWORD:
 # Keys configurable via environment variables and editable from the settings page.
 # Values provided in ``settings.yaml`` override these defaults.
 ENV_SETTING_KEYS = [
-    "JOURNALS_DIR",
     "DATA_DIR",
     "APP_DIR",
     "PROMPTS_FILE",

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -139,7 +139,6 @@ document.addEventListener("DOMContentLoaded", () => {
       };
     const envSettingCategories = {
       Paths: [
-        'JOURNALS_DIR',
         'DATA_DIR',
         'APP_DIR',
         'PROMPTS_FILE',
@@ -202,11 +201,6 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     const envKeyInfo = {
-      JOURNALS_DIR: {
-        label: 'Journals directory',
-        help: 'Path where journal files are stored',
-        placeholder: '/path/to/journals',
-      },
       DATA_DIR: {
         label: 'Data directory',
         help: 'Location for persistent data files',


### PR DESCRIPTION
## Summary
- remove JOURNALS_DIR from editable environment settings
- drop JOURNALS_DIR field from settings UI and example env file
- clarify in docs that JOURNALS_DIR only controls Docker volume mounts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689119a8e870833288e0a0f08555c0f9