### PR TITLE
Handle empty config values

### DIFF
--- a/src/echo_journal/config.py
+++ b/src/echo_journal/config.py
@@ -9,8 +9,18 @@ _SETTINGS = load_settings()
 
 
 def _get_setting(key: str, default: str | None = None) -> str | None:
-    """Return a configuration value from settings.yaml overriding environment variables."""
-    return _SETTINGS.get(key, os.getenv(key, default))
+    """Return a configuration value from settings.yaml overriding environment variables.
+
+    Empty strings in either source are treated as missing values so the
+    provided ``default`` is used instead. This prevents downstream code from
+    receiving empty strings when it expects ``None`` or a usable value.
+    """
+    value = _SETTINGS.get(key)
+    if value in (None, ""):
+        value = os.getenv(key, default)
+    if value == "":
+        return default
+    return value
 
 # Allow overriding important paths via environment variables for easier testing
 # and deployment in restricted environments.

--- a/src/echo_journal/immich_utils.py
+++ b/src/echo_journal/immich_utils.py
@@ -2,19 +2,16 @@
 
 import json
 import logging
-import os
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List
 
 import httpx
 
-from .config import IMMICH_URL, IMMICH_API_KEY
+from .config import IMMICH_URL, IMMICH_API_KEY, IMMICH_TIME_BUFFER
 
-# Allow widening the search range so photos close to midnight in other
-# timezones are included. The default of 15 hours covers even the most
-# extreme differences from UTC.
-IMMICH_TIME_BUFFER = int(os.getenv("IMMICH_TIME_BUFFER", "15"))
+# ``IMMICH_TIME_BUFFER`` is imported from ``config`` so empty environment values
+# fall back to the default defined there.
 
 logger = logging.getLogger("ej.immich")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,3 +24,16 @@ def test_get_setting_default(monkeypatch):
     monkeypatch.setattr(config, "_SETTINGS", {})
     monkeypatch.delenv("C", raising=False)
     assert config._get_setting("C", "def") == "def"
+
+
+def test_get_setting_empty_strings(monkeypatch):
+    """Empty strings should fall back to the provided default."""
+    # Empty value in settings should not override the default
+    monkeypatch.setattr(config, "_SETTINGS", {"D": ""})
+    monkeypatch.delenv("D", raising=False)
+    assert config._get_setting("D", "def") == "def"
+
+    # Empty environment variable should also fall back to the default
+    monkeypatch.setattr(config, "_SETTINGS", {})
+    monkeypatch.setenv("E", "")
+    assert config._get_setting("E", "def") == "def"


### PR DESCRIPTION
## Summary
- Avoid treating empty strings in configuration as valid values
- Import Immich time buffer from centralized config
- Cover empty-string config cases with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689123b3947083328c044fc14bca7800