### PR TITLE
Use config for OpenAI API key

### DIFF
--- a/src/echo_journal/ai_prompt_utils.py
+++ b/src/echo_journal/ai_prompt_utils.py
@@ -1,9 +1,10 @@
 """Utility functions for generating prompts via an AI API."""
 
-import os
 from typing import Optional
 
 import httpx
+
+from . import config
 
 OPENAI_URL = "https://api.openai.com/v1/completions"
 
@@ -11,11 +12,12 @@ OPENAI_URL = "https://api.openai.com/v1/completions"
 async def fetch_ai_prompt() -> Optional[str]:
     """Return a generated prompt from an AI service if available.
 
-    Uses the ``OPENAI_API_KEY`` environment variable. Returns ``None`` if the
-    key is missing or the request fails for any reason.
+    Uses ``config.OPENAI_API_KEY`` which may be provided via ``settings.yaml`` or
+    environment variables. Returns ``None`` if the key is missing or the request
+    fails for any reason.
     """
 
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = config.OPENAI_API_KEY
     if not api_key:
         return None
 

--- a/tests/test_ai_prompt_utils.py
+++ b/tests/test_ai_prompt_utils.py
@@ -3,7 +3,9 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code
 
 import asyncio
+
 from echo_journal import ai_prompt_utils as ai
+from echo_journal import config
 
 
 class FakeClient:
@@ -38,14 +40,14 @@ class FakeClient:
 
 def test_no_api_key(monkeypatch):
     """When no API key is set, ``fetch_ai_prompt`` returns ``None``."""
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(config, "OPENAI_API_KEY", None)
     assert asyncio.run(ai.fetch_ai_prompt()) is None
 
 
 def test_fetch_ai_prompt(monkeypatch):
     """Valid responses should return trimmed prompt text."""
     client = FakeClient({"choices": [{"text": "  Hello\n"}]})
-    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(config, "OPENAI_API_KEY", "x")
     monkeypatch.setattr(ai.httpx, "AsyncClient", lambda: client)
 
     prompt = asyncio.run(ai.fetch_ai_prompt())
@@ -53,3 +55,18 @@ def test_fetch_ai_prompt(monkeypatch):
     assert prompt == "Hello"
     assert client.captured["url"] == ai.OPENAI_URL
     assert client.captured["headers"]["Authorization"] == "Bearer x"
+
+
+def test_fetch_ai_prompt_from_settings(monkeypatch):
+    """API key provided via settings.yaml should be used."""
+    client = FakeClient({"choices": [{"text": "Hi"}]})
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(config, "_SETTINGS", {"OPENAI_API_KEY": "from_settings"})
+    monkeypatch.setattr(config, "OPENAI_API_KEY", config._get_setting("OPENAI_API_KEY"))
+    monkeypatch.setattr(ai, "config", config)
+    monkeypatch.setattr(ai.httpx, "AsyncClient", lambda: client)
+
+    prompt = asyncio.run(ai.fetch_ai_prompt())
+
+    assert prompt == "Hi"
+    assert client.captured["headers"]["Authorization"] == "Bearer from_settings"


### PR DESCRIPTION
## Summary
- pull OpenAI API key from echo_journal.config instead of environment
- exercise AI prompt helper when the key comes from settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68912819c0008332b535817746c8091f