### PR TITLE
fix: append ai prompts without clearing file

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -733,7 +733,8 @@ async def ai_prompt(
     prompts = await load_prompts()
     prompts.append(result)
     async with aiofiles.open(PROMPTS_FILE, "w", encoding=ENCODING) as fh:
-        yaml.safe_dump(prompts, fh, allow_unicode=True, sort_keys=False)
+        dump_text = yaml.safe_dump(prompts, allow_unicode=True, sort_keys=False)
+        await fh.write(dump_text)
     return {
         "prompt": result.get("prompt", ""),
         "anchor": result.get("anchor", ""),


### PR DESCRIPTION
## Summary
- restore prompts.yaml with existing prompts
- write AI-generated prompts to prompts.yaml without truncating the file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68914388b8348332a5ed41ca89d67232