### PR TITLE
Use gpt-4o-mini for AI prompts

### DIFF
--- a/src/echo_journal/ai_prompt_utils.py
+++ b/src/echo_journal/ai_prompt_utils.py
@@ -56,9 +56,9 @@ async def fetch_ai_prompt(anchor: str | None) -> Optional[Dict[str, Any]]:
     headers = {"Authorization": f"Bearer {api_key}"}
     prompt_text = AI_PROMPT_TEMPLATE.format(anchor=anchor)
     payload = {
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
         "messages": [{"role": "user", "content": prompt_text}],
-        "max_tokens": 200,
+        "max_tokens": 300,
     }
 
     try:

--- a/tests/test_ai_prompt_utils.py
+++ b/tests/test_ai_prompt_utils.py
@@ -57,6 +57,8 @@ def test_fetch_ai_prompt(monkeypatch):
     assert prompt == {"id": "tag-001", "prompt": "Hi", "tags": ["mood"], "anchor": "soft"}
     assert client.captured["url"] == ai.CHAT_URL
     assert client.captured["headers"]["Authorization"] == "Bearer x"
+    assert client.captured["json"]["model"] == "gpt-4o-mini"
+    assert client.captured["json"]["max_tokens"] == 300
     assert "soft" in client.captured["json"]["messages"][0]["content"]
 
 


### PR DESCRIPTION
## Summary
- switch AI prompt generation to use `gpt-4o-mini`
- allow larger responses by raising `max_tokens` to 300
- verify the expected model and token limit in AI prompt tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689148412db88332b57aeaee46817068