### PR TITLE
Improve AI prompt error handling

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -385,9 +385,16 @@
             }
             localStorage.setItem(promptKey, JSON.stringify({ prompt: currentPrompt, category: currentCategory, anchor: currentAnchor }));
           } else {
-            alert('Failed to fetch AI prompt.');
+            let msg = 'Failed to fetch AI prompt.';
+            try {
+              const err = await res.json();
+              if (err && err.detail) msg = err.detail;
+            } catch (_) {}
+            alert(msg);
           }
-        } catch (_) {}
+        } catch (_) {
+          alert('Failed to fetch AI prompt.');
+        }
       });
     }
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1176,6 +1176,7 @@ def test_ai_prompt_missing_key(test_client, monkeypatch):
         "/api/ai_prompt?mood=meh&energy=2", headers={"Authorization": f"Basic {token}"}
     )
     assert resp.status_code == 503
+    assert resp.json()["detail"] == "AI prompt unavailable"
 
 
 def test_ai_prompt_external_failure(test_client, monkeypatch):
@@ -1191,6 +1192,7 @@ def test_ai_prompt_external_failure(test_client, monkeypatch):
         "/api/ai_prompt?mood=meh&energy=2", headers={"Authorization": f"Basic {token}"}
     )
     assert resp.status_code == 503
+    assert resp.json()["detail"] == "AI prompt unavailable"
 
 
 def test_ai_prompt_defaults_anchor(test_client, monkeypatch):


### PR DESCRIPTION
## Summary
- surface server-provided details when the "Need inspiration" AI prompt fetch fails
- cover error detail in AI prompt endpoint tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68914b23e19c83329b23c49a151f6463