### PR TITLE
Refactor AI prompt utils to satisfy pylint

### DIFF
--- a/src/echo_journal/ai_prompt_utils.py
+++ b/src/echo_journal/ai_prompt_utils.py
@@ -1,10 +1,10 @@
 """Utility functions for generating prompts via an AI API."""
 
-from typing import Optional, Dict, Any
+import logging
+from typing import Any, Dict, Optional
 
 import httpx
 import yaml
-import logging
 
 from . import config
 
@@ -13,7 +13,8 @@ CHAT_URL = "https://api.openai.com/v1/chat/completions"
 AI_PROMPT_TEMPLATE = (
     "You are a journaling assistant for Echo Journal. Your job is to generate"
     " journaling prompts that match an anchor level of {anchor} and with 1-2"
-    " thematic strategies (tags). All prompts have the goal of helping the writer connect better with the day they are writing about.\n\n"
+    " thematic strategies (tags). All prompts have the goal of helping the writer connect better "
+    "with the day they are writing about.\n\n"
     "Anchor Levels\n"
     "micro: Can be answered in one word, emoji, or phrase. Used when energy is very low.\n"
     "soft: Gentle observational or sensory prompts. Easy to start, low emotional load.\n"
@@ -74,44 +75,49 @@ async def fetch_ai_prompt(anchor: str | None) -> Optional[Dict[str, Any]]:
             resp = await client.post(CHAT_URL, headers=headers, json=payload, timeout=10)
             resp.raise_for_status()
             data = resp.json()
-            choices = data.get("choices")
-            if not isinstance(choices, list) or not choices:
-                logger.warning("AI response missing choices: %s", data)
-                return None
-            message = choices[0].get("message", {})
-            content = message.get("content")
-
-            if isinstance(content, list):
-                text_parts = [
-                    part.get("text", "")
-                    for part in content
-                    if isinstance(part, dict) and part.get("type") == "text"
-                ]
-                content = "".join(text_parts)
-
-            if not isinstance(content, str) or not content.strip():
-                logger.warning("AI response had empty content: %s", content)
-                return None
-
-            content = content.strip()
-            if content.startswith("```"):
-                lines = content.splitlines()
-                if lines and lines[0].startswith("```"):
-                    lines = lines[1:]
-                if lines and lines[-1].startswith("```"):
-                    lines = lines[:-1]
-                content = "\n".join(lines).strip()
-
-            logger.debug("AI returned content: %s", content)
-
-            parsed = yaml.safe_load(content)
-            if isinstance(parsed, list) and parsed:
-                first = parsed[0]
-                if isinstance(first, dict):
-                    return first
-            logger.warning("AI response not in expected format: %s", content)
+            return _parse_ai_response(data)
     except (httpx.HTTPError, ValueError, KeyError, yaml.YAMLError) as exc:
         logger.error("AI prompt fetch failed: %s", exc)
+    return None
+
+
+def _parse_ai_response(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Extract the first prompt dictionary from an API response."""
+
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        logger.warning("AI response missing choices: %s", data)
         return None
 
+    message = choices[0].get("message", {})
+    content = message.get("content")
+    if isinstance(content, list):
+        text_parts = [
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        content = "".join(text_parts)
+
+    if not isinstance(content, str) or not content.strip():
+        logger.warning("AI response had empty content: %s", content)
+        return None
+
+    content = content.strip()
+    if content.startswith("```"):
+        lines = content.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        content = "\n".join(lines).strip()
+
+    logger.debug("AI returned content: %s", content)
+
+    parsed = yaml.safe_load(content)
+    if isinstance(parsed, list) and parsed:
+        first = parsed[0]
+        if isinstance(first, dict):
+            return first
+    logger.warning("AI response not in expected format: %s", content)
     return None

--- a/tests/test_ai_prompt_utils.py
+++ b/tests/test_ai_prompt_utils.py
@@ -1,6 +1,6 @@
 """Tests for AI prompt utilities."""
 
-# pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code
+# pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code,protected-access
 
 import asyncio
 

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -49,7 +49,7 @@ def test_load_settings_logs_missing_warning(tmp_path, caplog):
     p = tmp_path / "missing.yaml"
     with caplog.at_level(logging.WARNING, logger="ej.settings"):
         data = settings_utils.load_settings(p)
-    assert data == {}
+    assert not data
     assert any(str(p) in r.getMessage() for r in caplog.records)
 
 


### PR DESCRIPTION
## Summary
- refactor `fetch_ai_prompt` and add helper to parse API responses, trimming variable count and returns
- adjust tests to respect pylint rules and clean boolean check

## Testing
- `pylint $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d1b781548332ac9255f204883dcc