### PR TITLE
style: enhance archive entry chips and tabs

### DIFF
--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -19,10 +19,10 @@
   <details id="metadata-panel" class="meta-card md:w-1/4 {% if not (wotd or songs or media) %}hidden{% endif %}">
     <summary class="md:hidden cursor-pointer font-medium mb-2">Extras</summary>
     <div>
-      <div id="meta-tabs" class="flex border-b">
-        <button type="button" class="tab-btn flex-1 py-1 text-sm border-b-2 border-transparent text-gray-500 dark:text-gray-400" data-target="wotd-tab" {% if not wotd %}hidden{% endif %}>Word</button>
-        <button type="button" class="tab-btn flex-1 py-1 text-sm border-b-2 border-transparent text-gray-500 dark:text-gray-400" data-target="tv-tab" {% if not media %}hidden{% endif %}>TV</button>
-        <button type="button" class="tab-btn flex-1 py-1 text-sm border-b-2 border-transparent text-gray-500 dark:text-gray-400" data-target="music-tab" {% if not songs %}hidden{% endif %}>Music</button>
+      <div id="meta-tabs" class="flex justify-center gap-2 border-b">
+        <button type="button" class="tab-btn px-3 py-2 text-sm font-semibold tracking-wide uppercase border-b-2 border-transparent text-gray-500 dark:text-gray-400 rounded-t-md" data-target="wotd-tab" {% if not wotd %}hidden{% endif %}>Word</button>
+        <button type="button" class="tab-btn px-3 py-2 text-sm font-semibold tracking-wide uppercase border-b-2 border-transparent text-gray-500 dark:text-gray-400 rounded-t-md" data-target="tv-tab" {% if not media %}hidden{% endif %}>TV</button>
+        <button type="button" class="tab-btn px-3 py-2 text-sm font-semibold tracking-wide uppercase border-b-2 border-transparent text-gray-500 dark:text-gray-400 rounded-t-md" data-target="music-tab" {% if not songs %}hidden{% endif %}>Music</button>
       </div>
       <div id="wotd-tab" class="tab-content mt-2 {% if not wotd %}hidden{% endif %}">
         <div id="wotd-display" class="text-sm text-gray-600 dark:text-gray-300 italic">
@@ -52,20 +52,20 @@
       {% if mood or energy or weather or location %}
       {% set mood_map = {'sad': ['😔', 'Sad'], 'self-doubt': ['😶', 'Self-doubt'], 'meh': ['😐', 'Meh'], 'okay': ['😊', 'Okay'], 'joyful': ['😍', 'Joyful']} %}
       {% set energy_map = {'drained': ['🪫', 'Drained'], 'low': ['😴', 'Low'], 'ok': ['🙂', 'OK'], 'energized': ['⚡', 'Energized']} %}
-      <div id="inline-meta" class="flex flex-wrap gap-2 mt-4 text-xs">
+      <div id="inline-meta" class="flex flex-wrap gap-3 mt-4 text-sm">
         {% set mood_data = mood_map.get(mood) %}
         {% if mood_data %}
-        <span id="mood-display" class="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-200" title="Mood: {{ mood_data[1] }}">{{ mood_data[0] }} {{ mood_data[1] }}</span>
+        <span id="mood-display" class="px-3 py-1.5 bg-gray-300 dark:bg-gray-600 rounded-full text-gray-800 dark:text-gray-100 font-medium ring-1 ring-gray-400 dark:ring-gray-500" title="Mood: {{ mood_data[1] }}">{{ mood_data[0] }} {{ mood_data[1] }}</span>
         {% endif %}
         {% set energy_data = energy_map.get(energy) %}
         {% if energy_data %}
-        <span id="energy-display" class="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-200" title="Energy: {{ energy_data[1] }}">{{ energy_data[0] }} {{ energy_data[1] }}</span>
+        <span id="energy-display" class="px-3 py-1.5 bg-gray-300 dark:bg-gray-600 rounded-full text-gray-800 dark:text-gray-100 font-medium ring-1 ring-gray-400 dark:ring-gray-500" title="Energy: {{ energy_data[1] }}">{{ energy_data[0] }} {{ energy_data[1] }}</span>
         {% endif %}
         {% if weather %}
-        <span id="weather-display" class="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-200" title="{{ weather_raw }}">{{ weather }}</span>
+        <span id="weather-display" class="px-3 py-1.5 bg-gray-300 dark:bg-gray-600 rounded-full text-gray-800 dark:text-gray-100 font-medium ring-1 ring-gray-400 dark:ring-gray-500" title="{{ weather_raw }}">{{ weather }}</span>
         {% endif %}
         {% if location %}
-        <span id="location-display" class="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-200" title="Location: {{ location }}">📍 {{ location }}</span>
+        <span id="location-display" class="px-3 py-1.5 bg-gray-300 dark:bg-gray-600 rounded-full text-gray-800 dark:text-gray-100 font-medium ring-1 ring-gray-400 dark:ring-gray-500" title="Location: {{ location }}">📍 {{ location }}</span>
         {% endif %}
       </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- Enlarge and restyle inline metadata chips for higher visibility
- Improve spacing and styling for Word/TV/Music tab headers

## Testing
- `npm run build:css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d3cf658083328fb38a0c1b81f9c1