### PR TITLE
Center archive metadata chips and show weather descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ photos: []
 | Field | Purpose | Application usage |
 | ----- | ------- | ----------------- |
 | `location` | Human readable label from browser geolocation. | Shown with a 📍 icon in archive and entry views. |
-| `weather` | Temperature and weather code from Open‑Meteo. | Parsed by `format_weather` to show an icon and temperature. |
+| `weather` | Temperature and weather code from Open‑Meteo. | Parsed by `format_weather` to show an icon; codes are mapped to words for mouseover titles. |
 | `save_time` | Morning/Afternoon/Evening/Night recorded at save time. | Provides context for when the entry was written. |
 | `wotd` | Wordnik word of the day. | Displayed in the entry sidebar and as an icon in the archive list. |
 | `wotd_def` | Definition for the word of the day. | Shown alongside the word in entry views. |

--- a/src/echo_journal/file_utils.py
+++ b/src/echo_journal/file_utils.py
@@ -99,37 +99,46 @@ async def load_json_file(file_path: Path) -> List[Dict[str, Any]]:
         return []
 
 
-WEATHER_ICONS = {
-    0: "☀️",
-    1: "🌤️",
-    2: "⛅",
-    3: "☁️",
-    45: "🌫️",
-    48: "🌫️",
-    51: "🌦️",
-    53: "🌦️",
-    55: "🌦️",
-    61: "🌧️",
-    63: "🌧️",
-    65: "🌧️",
-    71: "❄️",
-    73: "❄️",
-    75: "❄️",
-    80: "🌦️",
-    81: "🌦️",
-    82: "🌧️",
-    95: "⛈️",
-    96: "⛈️",
-    99: "⛈️",
+WEATHER_CODES = {
+    0: ("☀️", "Clear"),
+    1: ("🌤️", "Mostly clear"),
+    2: ("⛅", "Partly cloudy"),
+    3: ("☁️", "Overcast"),
+    45: ("🌫️", "Fog"),
+    48: ("🌫️", "Fog"),
+    51: ("🌦️", "Drizzle"),
+    53: ("🌦️", "Drizzle"),
+    55: ("🌦️", "Drizzle"),
+    61: ("🌧️", "Rain"),
+    63: ("🌧️", "Rain"),
+    65: ("🌧️", "Heavy rain"),
+    71: ("❄️", "Snow"),
+    73: ("❄️", "Snow"),
+    75: ("❄️", "Snow"),
+    80: ("🌦️", "Showers"),
+    81: ("🌦️", "Showers"),
+    82: ("🌧️", "Heavy showers"),
+    95: ("⛈️", "Thunderstorm"),
+    96: ("⛈️", "Thunderstorm"),
+    99: ("⛈️", "Thunderstorm"),
 }
 
 
 def format_weather(weather: str) -> str:
-    """Return a formatted weather string like ``☀️ 20°C`` from frontmatter."""
+    """Return only the weather icon from ``weather`` frontmatter."""
     match = re.search(r"(-?\d+(?:\.\d+)?)°C code (\d+)", weather)
     if not match:
         return weather
-    temp = match.group(1)
     code = int(match.group(2))
-    icon = WEATHER_ICONS.get(code, "")
-    return f"{icon} {temp}°C".strip()
+    icon, _ = WEATHER_CODES.get(code, ("", ""))
+    return icon
+
+
+def weather_description(weather: str) -> str:
+    """Return a textual description from ``weather`` frontmatter."""
+    match = re.search(r"(-?\d+(?:\.\d+)?)°C code (\d+)", weather)
+    if not match:
+        return weather
+    code = int(match.group(2))
+    _, desc = WEATHER_CODES.get(code, ("", ""))
+    return desc

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -53,6 +53,7 @@ from .file_utils import (
     split_frontmatter,
     parse_frontmatter,
     format_weather,
+    weather_description,
     load_json_file,
 )
 from .immich_utils import update_photo_metadata
@@ -580,9 +581,9 @@ async def archive_entry(request: Request, entry_date: str):
             "prompt": prompt,
             "location": meta.get("location", ""),
             "weather": format_weather(meta["weather"]) if meta.get("weather") else "",
+            "weather_desc": weather_description(meta["weather"]) if meta.get("weather") else "",
             "mood": meta.get("mood", ""),
             "energy": meta.get("energy", ""),
-            "weather_raw": meta.get("weather", ""),
             "wotd": meta.get("wotd", ""),
             "wotd_def": meta.get("wotd_def", ""),
             "photos": photos,

--- a/templates/archive-entry.html
+++ b/templates/archive-entry.html
@@ -52,7 +52,7 @@
       {% if mood or energy or weather or location %}
       {% set mood_map = {'sad': ['😔', 'Sad'], 'self-doubt': ['😶', 'Self-doubt'], 'meh': ['😐', 'Meh'], 'okay': ['😊', 'Okay'], 'joyful': ['😍', 'Joyful']} %}
       {% set energy_map = {'drained': ['🪫', 'Drained'], 'low': ['😴', 'Low'], 'ok': ['🙂', 'OK'], 'energized': ['⚡', 'Energized']} %}
-      <div id="inline-meta" class="flex flex-wrap gap-4 mt-4 text-2xl">
+      <div id="inline-meta" class="flex flex-wrap gap-4 mt-4 text-2xl justify-center">
         {% set mood_data = mood_map.get(mood) %}
         {% if mood_data %}
         <span id="mood-display" class="flex items-center justify-center w-12 h-12 bg-gray-300 dark:bg-gray-600 rounded-full ring-1 ring-gray-400 dark:ring-gray-500" title="Mood: {{ mood_data[1] }}">{{ mood_data[0] }}</span>
@@ -62,7 +62,7 @@
         <span id="energy-display" class="flex items-center justify-center w-12 h-12 bg-gray-300 dark:bg-gray-600 rounded-full ring-1 ring-gray-400 dark:ring-gray-500" title="Energy: {{ energy_data[1] }}">{{ energy_data[0] }}</span>
         {% endif %}
         {% if weather %}
-        <span id="weather-display" class="flex items-center justify-center w-12 h-12 bg-gray-300 dark:bg-gray-600 rounded-full ring-1 ring-gray-400 dark:ring-gray-500" title="{{ weather_raw }}">{{ weather }}</span>
+        <span id="weather-display" class="flex items-center justify-center w-12 h-12 bg-gray-300 dark:bg-gray-600 rounded-full ring-1 ring-gray-400 dark:ring-gray-500" title="Weather: {{ weather_desc }}">{{ weather }}</span>
         {% endif %}
         {% if location %}
         <span id="location-display" class="flex items-center justify-center w-12 h-12 bg-gray-300 dark:bg-gray-600 rounded-full ring-1 ring-gray-400 dark:ring-gray-500" title="Location: {{ location }}">📍</span>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -332,7 +332,7 @@ def test_view_entry_uses_frontmatter(test_client):
     resp = test_client.get("/archive/2020-09-09")
     assert resp.status_code == 200
     assert "Testville" in resp.text
-    assert "12\u00b0C" in resp.text
+    assert 'title="Weather: Mostly clear"' in resp.text
 
 
 def test_view_entry_no_metadata_hidden(test_client):


### PR DESCRIPTION
## Summary
- Center inline metadata chips on archive entries
- Display only a weather icon and translate codes to descriptive tooltips
- Update tests and docs for new weather formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891e1513fb883329556df8082ef2a4a