### PR TITLE
Hide internal directories from settings API and UI

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -87,12 +87,11 @@ elif BASIC_AUTH_USERNAME or BASIC_AUTH_PASSWORD:
 
 # Keys configurable via environment variables and editable from the settings page.
 # Values provided in ``settings.yaml`` override these defaults.
+NON_EDITABLE_SETTING_KEYS = {"APP_DIR", "STATIC_DIR", "TEMPLATES_DIR"}
+
 ENV_SETTING_KEYS = [
     "DATA_DIR",
-    "APP_DIR",
     "PROMPTS_FILE",
-    "STATIC_DIR",
-    "TEMPLATES_DIR",
     "WORDNIK_API_KEY",
     "OPENAI_API_KEY",
     "IMMICH_URL",
@@ -839,6 +838,8 @@ async def get_settings() -> Dict[str, str]:
     # Include any additional keys from settings.yaml that aren't in
     # ``ENV_SETTING_KEYS``.
     for key, val in load_settings().items():
+        if key in NON_EDITABLE_SETTING_KEYS:
+            continue
         values.setdefault(key, val)
 
     return values
@@ -847,6 +848,8 @@ async def get_settings() -> Dict[str, str]:
 @app.post("/api/settings")
 async def update_settings(values: Dict[str, str]) -> Dict[str, str]:
     """Merge provided values into ``settings.yaml`` and return the updated mapping."""
+    for key in NON_EDITABLE_SETTING_KEYS:
+        values.pop(key, None)
     return save_settings(values)
 
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -140,10 +140,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const envSettingCategories = {
       Paths: [
         'DATA_DIR',
-        'APP_DIR',
         'PROMPTS_FILE',
-        'STATIC_DIR',
-        'TEMPLATES_DIR',
       ],
       'API Keys': [
         'WORDNIK_API_KEY',
@@ -206,25 +203,10 @@ document.addEventListener("DOMContentLoaded", () => {
         help: 'Location for persistent data files',
         placeholder: '/path/to/data',
       },
-      APP_DIR: {
-        label: 'Application directory',
-        help: 'Root path of the Echo Journal installation',
-        placeholder: '/path/to/app',
-      },
       PROMPTS_FILE: {
         label: 'Prompts file',
         help: 'YAML file containing writing prompts',
         placeholder: '/path/to/prompts.yaml',
-      },
-      STATIC_DIR: {
-        label: 'Static directory',
-        help: 'Directory for static assets like images and CSS',
-        placeholder: '/path/to/static',
-      },
-      TEMPLATES_DIR: {
-        label: 'Templates directory',
-        help: 'Directory containing HTML templates',
-        placeholder: '/path/to/templates',
       },
       WORDNIK_API_KEY: {
         label: 'Wordnik API key',


### PR DESCRIPTION
## Summary
- Remove APP_DIR, STATIC_DIR, and TEMPLATES_DIR from the settings page categories and key info
- Prevent APP_DIR, STATIC_DIR, and TEMPLATES_DIR from being returned or saved by the `/api/settings` endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e2044aa48332a99a254b9350fdce