### PR TITLE
feat: move settings file to hidden directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ This allows the backend to score prompts based on numeric intensity.
 ### Configuration
 
 On startup the application looks for a `settings.yaml` file in
-`<DATA_DIR>/settings.yaml` (default `/journals/settings.yaml`). If it is
+`<DATA_DIR>/.settings/settings.yaml` (default `/journals/.settings/settings.yaml`). If it is
 missing a warning is logged noting the expected path and the app falls back to
 environment variables. The `settings.yaml` file configures optional
 integrations and runtime paths. It is the authoritative source for these

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -9,14 +9,17 @@ from typing import Any, Dict
 import yaml
 
 # ``settings.yaml`` should live alongside the journal data so that it persists
-# outside of the application container.  Default to ``/journals`` but allow the
+# outside of the application container.  Store it within a dedicated
+# ``.settings`` directory under ``/journals`` by default, but allow the
 # location to be overridden via the ``DATA_DIR`` environment variable.  The
 # entire path can also be overridden via ``SETTINGS_PATH``.  When the default
-# data directory does not contain a settings file we fall back to looking inside
-# ``APP_DIR`` so that bundled defaults can be used on first run.
+# data directory does not contain a settings file we fall back to looking
+# inside ``APP_DIR`` so that bundled defaults can be used on first run.
 DATA_DIR = Path(os.getenv("DATA_DIR", "/journals"))
 APP_DIR = Path(os.getenv("APP_DIR", "/app"))
-SETTINGS_PATH = Path(os.getenv("SETTINGS_PATH", DATA_DIR / "settings.yaml"))
+SETTINGS_PATH = Path(
+    os.getenv("SETTINGS_PATH", DATA_DIR / ".settings" / "settings.yaml")
+)
 
 logger = logging.getLogger("ej.settings")
 

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -70,7 +70,7 @@ def test_settings_path_relative_to_data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(data_dir))
     importlib.reload(settings_utils)
     settings_utils.save_settings({"X": "1"})
-    expected = data_dir / "settings.yaml"
+    expected = data_dir / ".settings" / "settings.yaml"
     assert expected.read_text(encoding="utf-8") == "X: '1'\n"
     # Reset module to default state for other tests
     monkeypatch.delenv("DATA_DIR")
@@ -124,7 +124,7 @@ def test_load_settings_falls_back_to_app_dir(tmp_path, monkeypatch):
     assert data == {"A": "a"}
 
     settings_utils.save_settings({"B": "b"})
-    expected = data_dir / "settings.yaml"
+    expected = data_dir / ".settings" / "settings.yaml"
     assert yaml.safe_load(expected.read_text(encoding="utf-8")) == {"A": "a", "B": "b"}
 
     # Reset module to default state for other tests


### PR DESCRIPTION
## Summary
- save settings in /journals/.settings/settings.yaml by default
- update tests for new settings path
- document new settings location

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e78a4f548332a81309575016887a