### PR TITLE
Reduce settings page columns for responsive layout

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,7 +15,7 @@
     <p class="text-center text-gray-500 dark:text-gray-400">Enable or disable optional integrations and edit server settings. Values are saved to <code>settings.yaml</code>. Changes require a restart.</p>
     <fieldset id="integration-settings" class="space-y-2 text-left">
       <legend class="font-semibold text-lg">Integrations</legend>
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         <div class="meta-card flex items-center justify-between gap-4">
           <label for="integration-wordnik" class="flex items-center gap-2 cursor-pointer">
             <span class="text-2xl">📖</span>


### PR DESCRIPTION
## Summary
- Limit settings integrations grid to three columns on large screens and four on extra-large displays to avoid cramped layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891e8623b1c8332a52a18aabf3ef9ca