### PR TITLE
Redirect to settings when paths missing

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -23,7 +23,7 @@ import markdown
 import yaml
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, Query
-from fastapi.responses import HTMLResponse, JSONResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -59,7 +59,7 @@ from .file_utils import (
 from .immich_utils import update_photo_metadata
 from .jellyfin_utils import update_media_metadata, update_song_metadata
 from .prompt_utils import generate_prompt, _choose_anchor, load_prompts
-from .settings_utils import load_settings, save_settings
+from .settings_utils import load_settings, save_settings, SETTINGS_PATH
 from .weather_utils import build_frontmatter, time_of_day_label
 
 
@@ -154,6 +154,14 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
+def _needs_initial_setup() -> bool:
+    """Return True when essential paths or settings are missing."""
+    for path in (DATA_DIR, PROMPTS_FILE, SETTINGS_PATH):
+        if not path.exists():
+            return True
+    return False
+
+
 @app.middleware("http")
 async def basic_auth_middleware(request: Request, call_next):
     """Enforce optional HTTP Basic authentication."""
@@ -196,6 +204,8 @@ async def timing_middleware(request: Request, call_next):
 @app.get("/")
 async def index(request: Request):  # pylint: disable=too-many-locals
     """Render the journal entry page for the current day."""
+    if _needs_initial_setup():
+        return RedirectResponse(url="/settings", status_code=307)
     today = date.today()
     date_str = today.isoformat()
     file_path = safe_entry_path(date_str, DATA_DIR)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -42,6 +42,11 @@ DATA_ROOT.mkdir(parents=True, exist_ok=True)
 # copy prompts file if not already
 if not PROMPTS_FILE.exists():
     shutil.copy(ROOT / "prompts.yaml", PROMPTS_FILE)
+# ensure settings file exists so the app doesn't redirect during tests
+SETTINGS_PATH = DATA_ROOT / ".settings" / "settings.yaml"
+SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+if not SETTINGS_PATH.exists():
+    SETTINGS_PATH.write_text("{}", encoding="utf-8")
 
 # Make sure the package source directory is on ``sys.path`` so modules can be imported
 sys.path.insert(0, str(ROOT / "src"))
@@ -61,6 +66,10 @@ def test_client(tmp_path, monkeypatch):
     journals = tmp_path / "journals"
     journals.mkdir()
     monkeypatch.setattr(main, "DATA_DIR", journals)
+    # ensure settings file exists in case other tests removed it
+    main.SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if not main.SETTINGS_PATH.exists():
+        main.SETTINGS_PATH.write_text("{}", encoding="utf-8")
     return TestClient(main.app)
 
 
@@ -85,6 +94,22 @@ def test_restart_notice_absent_when_yesterday_exists(test_client):
     (main.DATA_DIR / f"{yesterday}.md").write_text("entry", encoding="utf-8")
     resp = test_client.get("/")
     assert "Restart from today?" not in resp.text
+
+
+def test_redirect_to_settings_when_prompts_missing(test_client, monkeypatch):
+    """Missing prompts file should redirect to the settings page."""
+    monkeypatch.setattr(main, "PROMPTS_FILE", Path("/nonexistent.yaml"))
+    resp = test_client.get("/", follow_redirects=False)
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/settings"
+
+
+def test_redirect_to_settings_when_settings_missing(test_client, monkeypatch):
+    """Missing settings file should redirect to the settings page."""
+    monkeypatch.setattr(main, "SETTINGS_PATH", Path("/no/settings.yaml"))
+    resp = test_client.get("/", follow_redirects=False)
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/settings"
 
 
 def test_save_entry_creates_file(test_client):


### PR DESCRIPTION
## Summary
- redirect to settings page when required paths or settings are missing
- cover redirects in endpoint tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891e9e915748332b94355a36045f0a2