### PR TITLE
refactor: reinitialize config-dependent globals on settings save

### DIFF
--- a/src/echo_journal/file_utils.py
+++ b/src/echo_journal/file_utils.py
@@ -9,11 +9,13 @@ from datetime import datetime
 import aiofiles
 import yaml
 
-from .config import DATA_DIR, ENCODING
+from . import config
 
 
-def safe_entry_path(entry_date: str, data_dir: Path = DATA_DIR) -> Path:
+def safe_entry_path(entry_date: str, data_dir: Path | None = None) -> Path:
     """Return a normalized path for the given entry date inside ``data_dir``."""
+    if data_dir is None:
+        data_dir = config.DATA_DIR
     sanitized = Path(entry_date).name
     sanitized = re.sub(r"[^0-9A-Za-z_-]", "_", sanitized)
     if not sanitized:
@@ -69,7 +71,7 @@ def split_frontmatter(text: str) -> Tuple[Optional[str], str]:
 async def read_existing_frontmatter(file_path: Path) -> Optional[str]:
     """Return frontmatter from the given file path if present."""
     try:
-        async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
+        async with aiofiles.open(file_path, "r", encoding=config.ENCODING) as fh:
             existing = await fh.read()
         frontmatter, _ = split_frontmatter(existing)
         return frontmatter
@@ -93,7 +95,7 @@ async def load_json_file(file_path: Path) -> List[Dict[str, Any]]:
     if not file_path.exists():
         return []
     try:
-        async with aiofiles.open(file_path, "r", encoding=ENCODING) as fh:
+        async with aiofiles.open(file_path, "r", encoding=config.ENCODING) as fh:
             return json.loads(await fh.read())
     except (OSError, ValueError):
         return []

--- a/src/echo_journal/immich_utils.py
+++ b/src/echo_journal/immich_utils.py
@@ -8,10 +8,23 @@ from typing import Any, Dict, List
 
 import httpx
 
-from .config import IMMICH_URL, IMMICH_API_KEY, IMMICH_TIME_BUFFER
+from . import config
 
-# ``IMMICH_TIME_BUFFER`` is imported from ``config`` so empty environment values
-# fall back to the default defined there.
+# Expose configuration values for tests while deriving from the config module.
+IMMICH_URL = config.IMMICH_URL
+IMMICH_API_KEY = config.IMMICH_API_KEY
+IMMICH_TIME_BUFFER = config.IMMICH_TIME_BUFFER
+
+# ``config.IMMICH_TIME_BUFFER`` ensures empty environment values fall back to
+# the default defined in the configuration module.
+
+
+def refresh_config() -> None:
+    """Refresh module-level configuration aliases."""
+    global IMMICH_URL, IMMICH_API_KEY, IMMICH_TIME_BUFFER
+    IMMICH_URL = config.IMMICH_URL
+    IMMICH_API_KEY = config.IMMICH_API_KEY
+    IMMICH_TIME_BUFFER = config.IMMICH_TIME_BUFFER
 
 logger = logging.getLogger("ej.immich")
 
@@ -37,7 +50,9 @@ async def fetch_assets_for_date(
 
     headers = {"x-api-key": IMMICH_API_KEY} if IMMICH_API_KEY else {}
 
-    logger.info("Fetching assets for %s from %s/api/search/metadata", date_str, IMMICH_URL)
+    logger.info(
+        "Fetching assets for %s from %s/api/search/metadata", date_str, IMMICH_URL
+    )
 
     try:
         async with httpx.AsyncClient() as client:

--- a/src/echo_journal/jellyfin_utils.py
+++ b/src/echo_journal/jellyfin_utils.py
@@ -9,13 +9,24 @@ from typing import Any, Dict, List, AsyncIterator
 
 import httpx
 
-from .config import (
-    JELLYFIN_URL,
-    JELLYFIN_API_KEY,
-    JELLYFIN_USER_ID,
-    JELLYFIN_PAGE_SIZE,
-    JELLYFIN_PLAY_THRESHOLD,
-)
+from . import config
+
+# Expose configuration values for tests while deriving from configuration
+JELLYFIN_URL = config.JELLYFIN_URL
+JELLYFIN_API_KEY = config.JELLYFIN_API_KEY
+JELLYFIN_USER_ID = config.JELLYFIN_USER_ID
+JELLYFIN_PAGE_SIZE = config.JELLYFIN_PAGE_SIZE
+JELLYFIN_PLAY_THRESHOLD = config.JELLYFIN_PLAY_THRESHOLD
+
+
+def refresh_config() -> None:
+    """Refresh module-level configuration aliases."""
+    global JELLYFIN_URL, JELLYFIN_API_KEY, JELLYFIN_USER_ID, JELLYFIN_PAGE_SIZE, JELLYFIN_PLAY_THRESHOLD
+    JELLYFIN_URL = config.JELLYFIN_URL
+    JELLYFIN_API_KEY = config.JELLYFIN_API_KEY
+    JELLYFIN_USER_ID = config.JELLYFIN_USER_ID
+    JELLYFIN_PAGE_SIZE = config.JELLYFIN_PAGE_SIZE
+    JELLYFIN_PLAY_THRESHOLD = config.JELLYFIN_PLAY_THRESHOLD
 
 logger = logging.getLogger("ej.jellyfin")
 

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -104,6 +104,22 @@ def save_settings(values: Dict[str, str], path: Path | None = None) -> Dict[str,
                 logger.debug("Reloading configuration module")
                 config_module = importlib.import_module("echo_journal.config")
                 importlib.reload(config_module)
+                try:
+                    from echo_journal import (
+                        main as main_module,
+                        prompt_utils,
+                        wordnik_utils,
+                        immich_utils,
+                        jellyfin_utils,
+                    )
+
+                    if hasattr(main_module, "reload_from_config"):
+                        main_module.reload_from_config()
+                    for mod in (prompt_utils, wordnik_utils, immich_utils, jellyfin_utils):
+                        if hasattr(mod, "refresh_config"):
+                            mod.refresh_config()
+                except Exception as exc:  # pragma: no cover - unexpected
+                    logger.error("Could not reinitialize app: %s", exc)
             except ImportError as exc:  # pragma: no cover - unexpected
                 logger.error("Could not reload config: %s", exc)
     return data

--- a/src/echo_journal/wordnik_utils.py
+++ b/src/echo_journal/wordnik_utils.py
@@ -6,9 +6,17 @@ from typing import Optional, Tuple
 
 import httpx
 
-from .config import WORDNIK_API_KEY
+from . import config
 
+# Expose API key for tests while deriving from configuration
+WORDNIK_API_KEY = config.WORDNIK_API_KEY
 WORDNIK_URL = "https://api.wordnik.com/v4/words.json/wordOfTheDay"
+
+
+def refresh_config() -> None:
+    """Refresh module-level configuration aliases."""
+    global WORDNIK_API_KEY
+    WORDNIK_API_KEY = config.WORDNIK_API_KEY
 
 
 async def fetch_word_of_day() -> Optional[Tuple[str, str]]:


### PR DESCRIPTION
## Summary
- load configuration via `config` module across utilities and expose refresh hooks
- add `reload_from_config` to rebuild auth, logging, and mounts when settings change
- ensure `save_settings` reloads config and refreshes dependent modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689206703f648332935fe5c9775eb079