### PR TITLE
Allow host/port and TLS configuration via env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ RUN pip install --no-cache-dir .
 # Copy only the built CSS artifact from the build stage
 COPY --from=build /app/static/tailwind.css ./static/tailwind.css
 EXPOSE 8000
-CMD ["uvicorn", "echo_journal.main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENV ECHO_JOURNAL_HOST=0.0.0.0
+ENV ECHO_JOURNAL_PORT=8000
+CMD ["python", "-m", "echo_journal.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       - ./static:/app/static
       - ./prompts.yaml:/app/prompts.yaml
       - ./data:/journals
+    environment:
+      - ECHO_JOURNAL_HOST=0.0.0.0
+      - ECHO_JOURNAL_PORT=8000
+      # Uncomment to enable TLS inside the container
+      # - ECHO_JOURNAL_SSL_KEYFILE=/path/to/key.pem
+      # - ECHO_JOURNAL_SSL_CERTFILE=/path/to/cert.pem

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -945,8 +945,30 @@ async def backfill_jellyfin_metadata() -> dict:
 
 
 def main() -> None:
-    """Run the Echo Journal ASGI application."""
-    uvicorn.run("echo_journal.main:app", host="0.0.0.0", port=8000)
+    """Run the Echo Journal ASGI application.
+
+    Host, port, and optional TLS settings can be overridden via the
+    ``ECHO_JOURNAL_HOST``, ``ECHO_JOURNAL_PORT``, ``ECHO_JOURNAL_SSL_KEYFILE``,
+    and ``ECHO_JOURNAL_SSL_CERTFILE`` environment variables. By default the
+    server binds to ``127.0.0.1:8000`` which is suitable when running behind a
+    reverse proxy that terminates TLS.
+    """
+
+    host = os.getenv("ECHO_JOURNAL_HOST", "127.0.0.1")
+    port = int(os.getenv("ECHO_JOURNAL_PORT", "8000"))
+    ssl_keyfile = os.getenv("ECHO_JOURNAL_SSL_KEYFILE")
+    ssl_certfile = os.getenv("ECHO_JOURNAL_SSL_CERTFILE")
+
+    ssl_args = {}
+    if ssl_keyfile and ssl_certfile:
+        ssl_args = {"ssl_keyfile": ssl_keyfile, "ssl_certfile": ssl_certfile}
+
+    uvicorn.run(
+        "echo_journal.main:app",
+        host=host,
+        port=port,
+        **ssl_args,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Read ECHO_JOURNAL_HOST, _PORT and optional TLS key/cert variables in app main
- Document default localhost binding and show reverse proxy example
- Surface host/port and TLS env vars in Dockerfile and docker-compose

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689211a80d0c83329d9f40538f8cce75