### PR TITLE
feat: derive app directory from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,10 @@ values:
 | Variable | Purpose | Notes / Defaults |
 | --- | --- | --- |
 | `DATA_DIR` | Internal application path. | Default `/journals`. |
-| `APP_DIR` | Internal application directory. | Default `/app`. |
-| `PROMPTS_FILE` | Location of YAML prompts file. | Default `/app/prompts.yaml`. |
-| `STATIC_DIR` | Directory for static assets. | Default `/app/static`. |
-| `TEMPLATES_DIR` | Directory for Jinja2 templates. | Default `/app/templates`. |
+| `APP_DIR` | Internal application directory. | Automatically derived from the installed package; override with `APP_DIR` env var if needed. |
+| `PROMPTS_FILE` | Location of YAML prompts file. | Default `<APP_DIR>/prompts.yaml`. |
+| `STATIC_DIR` | Directory for static assets. | Default `<APP_DIR>/static`. |
+| `TEMPLATES_DIR` | Directory for Jinja2 templates. | Default `<APP_DIR>/templates`. |
 | `WORDNIK_API_KEY` | Enables the Wordnik "word of the day" prompt. | |
 | `OPENAI_API_KEY` | Enables AI-generated prompts via the OpenAI API. | Usage may incur costs and is subject to OpenAI's rate limits. |
 | `IMMICH_URL` | URL of your Immich server. | |

--- a/src/echo_journal/config.py
+++ b/src/echo_journal/config.py
@@ -1,5 +1,6 @@
 """Core application paths and configuration constants."""
 
+from importlib.resources import files
 from pathlib import Path
 import os
 
@@ -22,9 +23,14 @@ def _get_setting(key: str, default: str | None = None) -> str | None:
         return default
     return value
 
+# Derive the application directory from the installed package location.  This
+# allows the code to run from arbitrary paths without requiring users to set
+# ``APP_DIR`` manually.  An environment variable can still override the value
+# for advanced scenarios such as tests or non-standard deployments.
+DEFAULT_APP_DIR = files("echo_journal").parent
 # Allow overriding important paths via environment variables for easier testing
 # and deployment in restricted environments.
-APP_DIR = Path(_get_setting("APP_DIR", "/app"))
+APP_DIR = Path(_get_setting("APP_DIR", str(DEFAULT_APP_DIR)))
 DATA_DIR = Path(_get_setting("DATA_DIR", "/journals"))
 PROMPTS_FILE = Path(_get_setting("PROMPTS_FILE", str(APP_DIR / "prompts.yaml")))
 STATIC_DIR = Path(_get_setting("STATIC_DIR", str(APP_DIR / "static")))

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -3,6 +3,7 @@
 import importlib
 import logging
 import os
+from importlib.resources import files
 from pathlib import Path
 from typing import Any, Dict
 
@@ -16,7 +17,11 @@ import yaml
 # data directory does not contain a settings file we fall back to looking
 # inside ``APP_DIR`` so that bundled defaults can be used on first run.
 DATA_DIR = Path(os.getenv("DATA_DIR", "/journals"))
-APP_DIR = Path(os.getenv("APP_DIR", "/app"))
+# Derive ``APP_DIR`` from the installed package location so the application can
+# locate bundled resources without requiring manual configuration. Advanced
+# deployments can still override this via the ``APP_DIR`` environment variable.
+DEFAULT_APP_DIR = files("echo_journal").parent
+APP_DIR = Path(os.getenv("APP_DIR", DEFAULT_APP_DIR))
 SETTINGS_PATH = Path(
     os.getenv("SETTINGS_PATH", DATA_DIR / ".settings" / "settings.yaml")
 )


### PR DESCRIPTION
## Summary
- derive APP_DIR from installed package so manual config isn't required
- allow env var override for APP_DIR and clarify defaults in docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892216a033483329343422cfad04b3f