### PR TITLE
Include static assets in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include prompts.yaml
+recursive-include templates *
+recursive-include static *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,8 @@ dependencies = [
 [project.scripts]
 "echo-journal" = "echo_journal.main:main"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- enable package data inclusion in `pyproject.toml`
- ship templates, static files, and prompts file via `MANIFEST.in`

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892240270e08332a2b8a618d7f4741b