### PR TITLE
Add setup script for environment and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,17 @@ with an AI helper. Below is the project roadmap and current feature set.
 
 ## Installation
 
-### Clone and install dependencies
+### Automated setup
+
+```bash
+git clone https://github.com/<your_user>/echo_journal.git
+cd echo_journal
+./scripts/setup.sh
+```
+
+The `setup.sh` script creates a `.venv`, installs Python dependencies, runs `npm install`, and builds the Tailwind CSS bundle.
+
+### Manual setup
 
 ```bash
 git clone https://github.com/<your_user>/echo_journal.git

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we're in the repository root
+d=$(dirname "$0")
+cd "$d/.."
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+  python -m venv .venv
+fi
+
+# Activate the virtual environment
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+# Install Python dependencies
+pip install .
+
+# Install Node dependencies and build CSS
+npm install
+npm run build:css


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to create a virtualenv, install Python and Node dependencies, and rebuild CSS
- document the new setup script under Installation in the README

## Testing
- `pip install .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68922d9a08188332bd855bd697915a62