### PR TITLE
Make docker compose configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Sample environment configuration for Docker Compose
+HOST_PORT=8510
+DATA_DIR=./data
+#TLS_KEY_PATH=./key.pem
+#TLS_CERT_PATH=./cert.pem

--- a/README.md
+++ b/README.md
@@ -68,21 +68,28 @@ Python dependencies are defined in `pyproject.toml` and installed with `pip inst
 
 > Note: The following commands use Docker Compose v2. If `docker compose` is unavailable, install the [Docker Compose plugin](https://docs.docker.com/compose/install/).
 
-1. **Prepare a persistent journals directory:**
+1. **Copy the example environment file and adjust settings as needed:**
+
+   ```bash
+   cp .env.example .env
+   # edit .env to change HOST_PORT, DATA_DIR, or TLS paths
+   ```
+
+2. **Prepare a persistent journals directory (matches `DATA_DIR`, default `data`):**
 
    ```bash
    mkdir -p data
    ```
 
-2. **Start the container:**
+3. **Start the container:**
 
    ```bash
    docker compose up --build
    ```
 
-   Then open <http://localhost:8510> in your browser.
+   Then open <http://localhost:8510> (or your chosen `HOST_PORT`) in your browser.
 
-3. **Stop the container while preserving data:**
+4. **Stop the container while preserving data:**
 
    ```bash
    docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ services:
   echo-journal:
     build: .
     ports:
-      - "8510:8000"
+      - "${HOST_PORT}:8000"
     volumes:
       - ./static:/app/static
       - ./prompts.yaml:/app/prompts.yaml
-      - ./data:/journals
+      - "${DATA_DIR}:/journals"
     environment:
       - ECHO_JOURNAL_HOST=0.0.0.0
       - ECHO_JOURNAL_PORT=8000
       # Uncomment to enable TLS inside the container
-      # - ECHO_JOURNAL_SSL_KEYFILE=/path/to/key.pem
-      # - ECHO_JOURNAL_SSL_CERTFILE=/path/to/cert.pem
+      # - ECHO_JOURNAL_SSL_KEYFILE=${TLS_KEY_PATH}
+      # - ECHO_JOURNAL_SSL_CERTFILE=${TLS_CERT_PATH}


### PR DESCRIPTION
## Summary
- add `.env.example` with host port, data directory, and TLS variables
- parameterize `docker-compose.yml` to use environment variables
- document `.env` usage in Docker Compose instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68922da32fe48332a68f7406f1bc4642