### PR TITLE
Improve .env parsing and path handling

### DIFF
--- a/src/echo_journal/env_utils.py
+++ b/src/echo_journal/env_utils.py
@@ -1,10 +1,21 @@
 """Helpers for reading .env files."""
 
 import logging
+import os
+import shlex
 from pathlib import Path
 from typing import Dict
 
-ENV_PATH = Path(".env")
+
+# Absolute path to the project's ``.env`` file. It can be overridden with the
+# ``ECHO_JOURNAL_ENV_PATH`` environment variable so that calls from any working
+# directory can locate the file.
+ENV_PATH = Path(
+    os.environ.get(
+        "ECHO_JOURNAL_ENV_PATH",
+        Path(__file__).resolve().parents[2] / ".env",
+    )
+).expanduser().resolve()
 
 logger = logging.getLogger("ej.env")
 
@@ -18,10 +29,13 @@ def load_env(path: Path | None = None) -> Dict[str, str]:
         with path.open("r", encoding="utf-8") as fh:
             for line in fh:
                 line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
+                if not line or line.startswith("#"):
                     continue
-                key, value = line.split("=", 1)
-                env[key.strip()] = value.strip()
+                for token in shlex.split(line, comments=True, posix=True):
+                    if "=" not in token:
+                        continue
+                    key, value = token.split("=", 1)
+                    env[key] = value
     except OSError as exc:
         logger.error("Could not read %s: %s", path, exc)
     return env

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,5 +1,6 @@
 """Tests for ``env_utils`` helpers."""
 
+import importlib
 import logging
 
 from echo_journal import env_utils
@@ -13,6 +14,14 @@ def test_load_env_parses_pairs(tmp_path):
     assert env == {"A": "1", "B": "two"}
 
 
+def test_load_env_handles_quotes_and_equals(tmp_path):
+    """Quoted values and additional ``=`` characters should be parsed."""
+    p = tmp_path / "quoted.env"
+    p.write_text('A="hello world"\nB=foo=bar\nC="x=y"\n', encoding="utf-8")
+    env = env_utils.load_env(p)
+    assert env == {"A": "hello world", "B": "foo=bar", "C": "x=y"}
+
+
 def test_load_env_logs_error(tmp_path, caplog):
     """Missing files should log an error and return an empty dict."""
     p = tmp_path / "missing.env"
@@ -20,3 +29,17 @@ def test_load_env_logs_error(tmp_path, caplog):
         env = env_utils.load_env(p)
     assert not env
     assert any(str(p) in r.getMessage() for r in caplog.records)
+
+
+def test_load_env_from_alternate_cwd(tmp_path, monkeypatch):
+    """Default ``ENV_PATH`` should work regardless of the current directory."""
+    env_file = tmp_path / "alt.env"
+    env_file.write_text("A=1\n", encoding="utf-8")
+    monkeypatch.setenv("ECHO_JOURNAL_ENV_PATH", str(env_file))
+    importlib.reload(env_utils)
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+    assert env_utils.load_env() == {"A": "1"}
+    monkeypatch.delenv("ECHO_JOURNAL_ENV_PATH", raising=False)
+    importlib.reload(env_utils)


### PR DESCRIPTION
## Summary
- Parse `.env` entries with `shlex` to support quotes and `=` in values
- Resolve `ENV_PATH` from project root or `ECHO_JOURNAL_ENV_PATH` env var
- Add tests for quoted values and using `.env` from different working dirs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68922dea55048332b34bf7a3b4e528f7