### PR TITLE
docs: add settings example and configuration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Python dependencies are defined in `pyproject.toml` and installed with `pip inst
 
    Journal files remain in the mounted `data` directory on the host.
 
+## Configuration
+
+To override default paths or provide API credentials, copy the example settings
+file and adjust values as needed:
+
+```bash
+cp settings.example.yaml settings.yaml
+# edit settings.yaml to set DATA_DIR, APP_DIR, and API keys
+```
+
 ## Example walkthrough
 
 To verify the app runs, try the following sequence:

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -1,0 +1,16 @@
+# Example configuration for Echo Journal
+# Copy this file to settings.yaml and adjust values as needed.
+
+# Base directories
+DATA_DIR: /journals
+APP_DIR: /app/echo_journal
+
+# Optional API integrations
+WORDNIK_API_KEY: your-wordnik-api-key
+OPENAI_API_KEY: your-openai-api-key
+IMMICH_URL: http://localhost:2283
+IMMICH_API_KEY: your-immich-api-key
+JELLYFIN_URL: http://localhost:8096
+JELLYFIN_API_KEY: your-jellyfin-api-key
+JELLYFIN_USER_ID: your-jellyfin-user-id
+NOMINATIM_USER_AGENT: EchoJournal/1.0 (you@example.com)


### PR DESCRIPTION
## Summary
- add sample `settings.example.yaml` with common directory and API key placeholders
- document configuration by referencing sample settings file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892306c76288332a03ec82a0e60722b