### PR TITLE
Use HTTPS for numbersapi

### DIFF
--- a/src/echo_journal/numbers_utils.py
+++ b/src/echo_journal/numbers_utils.py
@@ -12,10 +12,10 @@ async def fetch_date_fact(day: date) -> Optional[str]:
     Uses numbersapi.com to fetch a trivia fact about the supplied date.
     Returns ``None`` if the request fails or the response is malformed.
     """
-    url = f"http://numbersapi.com/{day.month}/{day.day}/date"
+    url = f"https://numbersapi.com/{day.month}/{day.day}/date?json"
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, params={"json": True}, timeout=10)
+            resp = await client.get(url, timeout=10)
             resp.raise_for_status()
             data = resp.json()
             text = data.get("text")

--- a/tests/test_numbers_utils.py
+++ b/tests/test_numbers_utils.py
@@ -1,0 +1,51 @@
+"""Tests for number fact utilities."""
+
+# pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code
+
+import asyncio
+from datetime import date
+
+from echo_journal import numbers_utils as nu
+
+
+class FakeClient:
+    """Minimal ``httpx.AsyncClient`` stand-in."""
+
+    def __init__(self, data):
+        self._data = data
+        self.captured = {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, params=None, timeout=None):
+        self.captured["url"] = url
+        self.captured["params"] = params
+
+        class Response:
+            def __init__(self, data):
+                self._data = data
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._data
+
+        return Response(self._data)
+
+
+def test_fetch_date_fact(monkeypatch):
+    """The request should use HTTPS and the ``?json`` flag."""
+    client = FakeClient({"text": "a fact"})
+    monkeypatch.setattr(nu.httpx, "AsyncClient", lambda: client)
+
+    result = asyncio.run(nu.fetch_date_fact(date(2024, 1, 2)))
+
+    assert result == "a fact"
+    assert client.captured["url"].startswith("https://")
+    assert client.captured["url"].endswith("/1/2/date?json")
+    assert client.captured["params"] is None


### PR DESCRIPTION
## Summary
- use HTTPS and `?json` flag when requesting numbersapi date facts
- add unit test verifying HTTPS URL and parameter handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689230d90fa8833290a952b7edeb1fc6