### PR TITLE
Coerce settings values to strings before saving

### DIFF
--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -88,13 +88,21 @@ def load_settings(path: Path | None = None) -> Dict[str, str]:
         return {}
 
 
-def save_settings(values: Dict[str, str], path: Path | None = None) -> Dict[str, str]:
+def save_settings(values: Dict[str, Any], path: Path | None = None) -> Dict[str, str]:
     """Merge ``values`` into the settings file and return updated mapping."""
     if path is None:
         path = SETTINGS_PATH
     logger.debug("Saving settings to %s: %s", path, values)
     data = load_settings(path)
-    data.update(values)
+    cleaned: Dict[str, str] = {}
+    for k, v in values.items():
+        if v is None:
+            cleaned[str(k)] = ""
+        elif isinstance(v, bool):
+            cleaned[str(k)] = "true" if v else "false"
+        else:
+            cleaned[str(k)] = str(v)
+    data.update(cleaned)
     logger.debug("Merged settings: %s", data)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_settings_utils.py
+++ b/tests/test_settings_utils.py
@@ -44,6 +44,20 @@ def test_save_settings_merges(tmp_path):
     assert yaml.safe_load(p.read_text(encoding="utf-8")) == {"A": "a", "B": "b"}
 
 
+def test_save_settings_coerces_non_strings(tmp_path):
+    """Non-string values should be coerced to strings when saving."""
+    p = tmp_path / "settings.yaml"
+    p.write_text("A: a\n", encoding="utf-8")
+    result = settings_utils.save_settings({"B": 2, "C": True, "D": None}, p)
+    assert result == {"A": "a", "B": "2", "C": "true", "D": ""}
+    assert yaml.safe_load(p.read_text(encoding="utf-8")) == {
+        "A": "a",
+        "B": "2",
+        "C": "true",
+        "D": "",
+    }
+
+
 def test_load_settings_logs_missing_warning(tmp_path, caplog):
     """Missing files should log a warning with the expected path."""
     p = tmp_path / "missing.yaml"


### PR DESCRIPTION
## Summary
- sanitize non-string values in `save_settings` to ensure they're stored as strings
- add tests verifying that non-string inputs are coerced when saving settings

## Testing
- `pytest tests/test_settings_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689234bfeb3483329689c7f0096b4234