### PR TITLE
Allow configuring Immich host

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -84,12 +84,22 @@ templates: Jinja2Templates
 
 def _refresh_config_vars() -> None:
     """Refresh module-level aliases to configuration values."""
-    global DATA_DIR, PROMPTS_FILE, IMMICH_URL, IMMICH_API_KEY, NOMINATIM_USER_AGENT
+    global DATA_DIR, PROMPTS_FILE, IMMICH_URL, IMMICH_API_KEY, NOMINATIM_USER_AGENT, IMMICH_ALLOWED_HOSTS
     DATA_DIR = config.DATA_DIR
     PROMPTS_FILE = config.PROMPTS_FILE
     IMMICH_URL = config.IMMICH_URL
     IMMICH_API_KEY = config.IMMICH_API_KEY
     NOMINATIM_USER_AGENT = config.NOMINATIM_USER_AGENT
+
+    # Restrict Immich asset proxying to known hosts derived from configuration.
+    IMMICH_ALLOWED_HOSTS = {"immich", "localhost"}
+    if IMMICH_URL:
+        try:
+            host = urlparse(IMMICH_URL).hostname
+        except ValueError:
+            host = None
+        if host:
+            IMMICH_ALLOWED_HOSTS.add(host)
 
 
 def _configure_auth() -> None:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1013,6 +1013,18 @@ def test_asset_proxy_disallowed_host(test_client, monkeypatch, caplog):
     assert "Blocked Immich host" in caplog.text
 
 
+def test_refresh_config_vars_adds_immich_host(monkeypatch):
+    """Host from IMMICH_URL should be included in allowed host set."""
+    monkeypatch.setattr(main.config, "IMMICH_URL", "http://photos.example.com/api")
+
+    main._refresh_config_vars()
+    assert "photos.example.com" in main.IMMICH_ALLOWED_HOSTS
+
+    # Restore default configuration for subsequent tests
+    monkeypatch.setattr(main.config, "IMMICH_URL", None)
+    main._refresh_config_vars()
+
+
 def test_thumbnail_proxy_download(test_client, monkeypatch):
     """Thumbnail proxy endpoint should fetch thumbnail from Immich."""
 


### PR DESCRIPTION
## Summary
- ensure Immich proxy hosts refresh from IMMICH_URL
- test that configuration refresh includes Immich host

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689292701c70833288fa74bac2a0fd6d