### PR TITLE
chore: quiet linter warnings

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -1,6 +1,6 @@
 """Echo Journal FastAPI application."""
 
-# pylint: disable=import-error
+# pylint: disable=import-error,too-many-lines,global-statement
 
 import asyncio
 import base64
@@ -84,7 +84,8 @@ templates: Jinja2Templates
 
 def _refresh_config_vars() -> None:
     """Refresh module-level aliases to configuration values."""
-    global DATA_DIR, PROMPTS_FILE, IMMICH_URL, IMMICH_API_KEY, NOMINATIM_USER_AGENT, IMMICH_ALLOWED_HOSTS
+    global DATA_DIR, PROMPTS_FILE, IMMICH_URL, IMMICH_API_KEY, NOMINATIM_USER_AGENT, \
+        IMMICH_ALLOWED_HOSTS
     DATA_DIR = config.DATA_DIR
     PROMPTS_FILE = config.PROMPTS_FILE
     IMMICH_URL = config.IMMICH_URL

--- a/src/echo_journal/prompt_utils.py
+++ b/src/echo_journal/prompt_utils.py
@@ -1,5 +1,7 @@
 """Prompt loading and generation helpers."""
 
+# pylint: disable=global-statement
+
 import asyncio
 import logging
 import random

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -89,6 +89,7 @@ def load_settings(path: Path | None = None) -> Dict[str, str]:
 
 
 def save_settings(values: Dict[str, Any], path: Path | None = None) -> Dict[str, str]:
+    # pylint: disable=too-many-branches,too-many-nested-blocks
     """Merge ``values`` into the settings file and return updated mapping."""
     if path is None:
         path = SETTINGS_PATH
@@ -118,7 +119,7 @@ def save_settings(values: Dict[str, Any], path: Path | None = None) -> Dict[str,
                 config_module = importlib.import_module("echo_journal.config")
                 importlib.reload(config_module)
                 try:
-                    from echo_journal import (
+                    from echo_journal import (  # pylint: disable=import-outside-toplevel
                         main as main_module,
                         prompt_utils,
                         wordnik_utils,
@@ -131,7 +132,7 @@ def save_settings(values: Dict[str, Any], path: Path | None = None) -> Dict[str,
                     for mod in (prompt_utils, wordnik_utils, immich_utils, jellyfin_utils):
                         if hasattr(mod, "refresh_config"):
                             mod.refresh_config()
-                except Exception as exc:  # pragma: no cover - unexpected
+                except Exception as exc:  # pragma: no cover - unexpected  # pylint: disable=broad-exception-caught
                     logger.error("Could not reinitialize app: %s", exc)
             except ImportError as exc:  # pragma: no cover - unexpected
                 logger.error("Could not reload config: %s", exc)

--- a/src/echo_journal/wordnik_utils.py
+++ b/src/echo_journal/wordnik_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for interacting with the Wordnik API."""
 
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code,global-statement
 
 from typing import Optional, Tuple
 

--- a/tests/test_wordnik_utils.py
+++ b/tests/test_wordnik_utils.py
@@ -1,6 +1,5 @@
-"""Tests for Wordnik utilities."""
-
 # pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument,duplicate-code,cyclic-import
+"""Tests for Wordnik utilities."""
 
 import asyncio
 


### PR DESCRIPTION
## Summary
- suppress Pylint's global statements warnings in core modules
- note heavy branching in save_settings and relax import/broad-exception rules
- move Pylint disables to the start of Wordnik tests

## Testing
- `pytest`
- `pylint src/echo_journal/settings_utils.py tests/test_wordnik_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68929e92675c83329d04b3a5600f677f