### PR TITLE
refactor: remove global wordnik api state

### DIFF
--- a/src/echo_journal/wordnik_utils.py
+++ b/src/echo_journal/wordnik_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for interacting with the Wordnik API."""
 
-# pylint: disable=duplicate-code,global-statement
+# pylint: disable=duplicate-code
 
 from typing import Optional, Tuple
 
@@ -8,21 +8,23 @@ import httpx
 
 from . import config
 
-# Expose API key for tests while deriving from configuration
-WORDNIK_API_KEY = config.WORDNIK_API_KEY
 WORDNIK_URL = "https://api.wordnik.com/v4/words.json/wordOfTheDay"
 
 
-def refresh_config() -> None:
-    """Refresh module-level configuration aliases."""
-    global WORDNIK_API_KEY
-    WORDNIK_API_KEY = config.WORDNIK_API_KEY
+def get_api_key() -> Optional[str]:
+    """Return the configured Wordnik API key.
+
+    The indirection allows tests to override how the key is retrieved without
+    resorting to modifying module-level globals.
+    """
+
+    return config.WORDNIK_API_KEY
 
 
 async def fetch_word_of_day() -> Optional[Tuple[str, str]]:
     """Return today's Wordnik word of the day and definition if available."""
 
-    api_key = WORDNIK_API_KEY
+    api_key = get_api_key()
     if not api_key:
         return None
     try:

--- a/tests/test_wordnik_utils.py
+++ b/tests/test_wordnik_utils.py
@@ -38,14 +38,14 @@ class FakeClient:
 
 def test_no_api_key(monkeypatch):
     """Missing API key should return ``None``."""
-    monkeypatch.setattr(wu, "WORDNIK_API_KEY", None)
+    monkeypatch.setattr(wu, "get_api_key", lambda: None)
     assert asyncio.run(wu.fetch_word_of_day()) is None
 
 
 def test_fetch_word_of_day(monkeypatch):
     """Valid responses should return word and definition."""
     client = FakeClient({"word": "apple", "definitions": [{"text": "a fruit"}]})
-    monkeypatch.setattr(wu, "WORDNIK_API_KEY", "k")
+    monkeypatch.setattr(wu, "get_api_key", lambda: "k")
     monkeypatch.setattr(wu.httpx, "AsyncClient", lambda: client)
 
     result = asyncio.run(wu.fetch_word_of_day())


### PR DESCRIPTION
## Summary
- avoid global variable usage for Wordnik API key by introducing `get_api_key`
- adjust `fetch_word_of_day` and its tests to use the new accessor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892a500b0a883329b65a077976e1034