### PR TITLE
docs: move configuration details to dedicated doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ with an AI helper. Below is the project roadmap and current feature set.
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Usage](#usage)
-- [Configuration](#configuration)
+- [Configuration](#configuration) ([details](docs/configuration.md))
 - [Security considerations](#security-considerations)
 - [CLI commands](#cli-commands)
 - [API reference](#api-reference)
@@ -111,13 +111,17 @@ Python dependencies are defined in `pyproject.toml` and installed with `pip inst
 
 ## Configuration
 
-To override default paths or provide API credentials, copy the example settings
-file and adjust values as needed:
+Echo Journal reads options from `<DATA_DIR>/.settings/settings.yaml` (default
+`/journals/.settings/settings.yaml`). If the file is missing, environment
+variables are used instead. Copy the example file to get started:
 
 ```bash
 cp settings.example.yaml settings.yaml
 # edit settings.yaml to set DATA_DIR, APP_DIR, and API keys
 ```
+
+See [docs/configuration.md](docs/configuration.md) for a full list of
+configuration values and defaults.
 
 ## Example walkthrough
 
@@ -228,50 +232,6 @@ This allows the backend to score prompts based on numeric intensity.
 | `low` | 2 |
 | `ok` | 3 |
 | `energized` | 4 |
-
-### Configuration
-
-On startup the application looks for a `settings.yaml` file in
-`<DATA_DIR>/.settings/settings.yaml` (default `/journals/.settings/settings.yaml`). If it is
-missing a warning is logged noting the expected path and the app falls back to
-environment variables. The `settings.yaml` file configures optional
-integrations and runtime paths. It is the authoritative source for these
-values:
-
-| Variable | Purpose | Notes / Defaults |
-| --- | --- | --- |
-| `DATA_DIR` | Internal application path. | Default `/journals`. |
-| `APP_DIR` | Internal application directory. | Automatically derived from the installed package; override with `APP_DIR` env var if needed. |
-| `PROMPTS_FILE` | Location of YAML prompts file. | Default `<APP_DIR>/prompts.yaml`. |
-| `STATIC_DIR` | Directory for static assets. | Default `<APP_DIR>/static`. |
-| `TEMPLATES_DIR` | Directory for Jinja2 templates. | Default `<APP_DIR>/templates`. |
-| `WORDNIK_API_KEY` | Enables the Wordnik "word of the day" prompt. | |
-| `OPENAI_API_KEY` | Enables AI-generated prompts via the OpenAI API. | Usage may incur costs and is subject to OpenAI's rate limits. |
-| `IMMICH_URL` | URL of your Immich server. | |
-| `IMMICH_API_KEY` | API key for Immich. | |
-| `IMMICH_TIME_BUFFER` | Hour window to fetch photos. | Default `15`. |
-| `JELLYFIN_URL` | Base URL of Jellyfin server. | |
-| `JELLYFIN_API_KEY` | API key for Jellyfin. | |
-| `JELLYFIN_USER_ID` | Jellyfin user ID. | |
-| `JELLYFIN_PAGE_SIZE` | Pagination size for Jellyfin API. | Default `200`. |
-| `JELLYFIN_PLAY_THRESHOLD` | Percent threshold for "played". | Default `90`. |
-| `NOMINATIM_USER_AGENT` | Identifies your app when calling the Nominatim reverse geocoding API. | Include contact info per the usage policy. |
-| `LOG_LEVEL` | Logging verbosity. | Default `DEBUG`. |
-| `LOG_FILE` | Path to log file. | Default `/journals/.logs/echo_journal.log`; if empty, logs to stderr. |
-| `LOG_MAX_BYTES` | Max size before log rotation. | Default `1,048,576`. |
-| `LOG_BACKUP_COUNT` | Number of rotated log files. | Default `3`. |
-| `ECHO_JOURNAL_HOST` | Network interface to bind to. | Default `127.0.0.1`; set to `0.0.0.0` when using a reverse proxy. |
-| `ECHO_JOURNAL_PORT` | Port to listen on. | Default `8000`. |
-| `ECHO_JOURNAL_SSL_KEYFILE` | Path to TLS key file. | Used with `ECHO_JOURNAL_SSL_CERTFILE` to enable HTTPS. |
-| `ECHO_JOURNAL_SSL_CERTFILE` | Path to TLS certificate. | Used with `ECHO_JOURNAL_SSL_KEYFILE` to enable HTTPS. |
-| `BASIC_AUTH_USERNAME` | Username for optional HTTP Basic authentication. | |
-| `BASIC_AUTH_PASSWORD` | Password for optional HTTP Basic authentication. | |
-
-Set any of these variables in `settings.yaml` to tailor the app to your setup.
-Values provided via environment variables can override the defaults, but
-`settings.yaml` takes precedence. The **Settings** page lists current values
-and lets you edit them; changes are written to `settings.yaml` and take effect
-after restarting the server.
 
 ### Disabling integrations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,34 @@
+# Configuration
+
+On startup the application looks for a `settings.yaml` file in `<DATA_DIR>/.settings/settings.yaml` (default `/journals/.settings/settings.yaml`). If it is missing a warning is logged noting the expected path and the app falls back to environment variables. The `settings.yaml` file configures optional integrations and runtime paths. It is the authoritative source for these values:
+
+| Variable | Purpose | Notes / Defaults |
+| --- | --- | --- |
+| `DATA_DIR` | Internal application path. | Default `/journals`. |
+| `APP_DIR` | Internal application directory. | Automatically derived from the installed package; override with `APP_DIR` env var if needed. |
+| `PROMPTS_FILE` | Location of YAML prompts file. | Default `<APP_DIR>/prompts.yaml`. |
+| `STATIC_DIR` | Directory for static assets. | Default `<APP_DIR>/static`. |
+| `TEMPLATES_DIR` | Directory for Jinja2 templates. | Default `<APP_DIR>/templates`. |
+| `WORDNIK_API_KEY` | Enables the Wordnik "word of the day" prompt. | |
+| `OPENAI_API_KEY` | Enables AI-generated prompts via the OpenAI API. | Usage may incur costs and is subject to OpenAI's rate limits. |
+| `IMMICH_URL` | URL of your Immich server. | |
+| `IMMICH_API_KEY` | API key for Immich. | |
+| `IMMICH_TIME_BUFFER` | Hour window to fetch photos. | Default `15`. |
+| `JELLYFIN_URL` | Base URL of Jellyfin server. | |
+| `JELLYFIN_API_KEY` | API key for Jellyfin. | |
+| `JELLYFIN_USER_ID` | Jellyfin user ID. | |
+| `JELLYFIN_PAGE_SIZE` | Pagination size for Jellyfin API. | Default `200`. |
+| `JELLYFIN_PLAY_THRESHOLD` | Percent threshold for "played". | Default `90`. |
+| `NOMINATIM_USER_AGENT` | Identifies your app when calling the Nominatim reverse geocoding API. | Include contact info per the usage policy. |
+| `LOG_LEVEL` | Logging verbosity. | Default `DEBUG`. |
+| `LOG_FILE` | Path to log file. | Default `/journals/.logs/echo_journal.log`; if empty, logs to stderr. |
+| `LOG_MAX_BYTES` | Max size before log rotation. | Default `1,048,576`. |
+| `LOG_BACKUP_COUNT` | Number of rotated log files. | Default `3`. |
+| `ECHO_JOURNAL_HOST` | Network interface to bind to. | Default `127.0.0.1`; set to `0.0.0.0` when using a reverse proxy. |
+| `ECHO_JOURNAL_PORT` | Port to listen on. | Default `8000`. |
+| `ECHO_JOURNAL_SSL_KEYFILE` | Path to TLS key file. | Used with `ECHO_JOURNAL_SSL_CERTFILE` to enable HTTPS. |
+| `ECHO_JOURNAL_SSL_CERTFILE` | Path to TLS certificate. | Used with `ECHO_JOURNAL_SSL_KEYFILE` to enable HTTPS. |
+| `BASIC_AUTH_USERNAME` | Username for optional HTTP Basic authentication. | |
+| `BASIC_AUTH_PASSWORD` | Password for optional HTTP Basic authentication. | |
+
+Set any of these variables in `settings.yaml` to tailor the app to your setup. Values provided via environment variables can override the defaults, but `settings.yaml` takes precedence. The **Settings** page lists current values and lets you edit them; changes are written to `settings.yaml` and take effect after restarting the server.


### PR DESCRIPTION
## Summary
- move full configuration table into new documentation page
- replace README configuration section with brief summary and link
- add configuration doc to README navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893219ef868833292cf6934bab8807e