### PR TITLE
Fix YAML quoting for fact of the day

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -407,9 +407,11 @@ def _update_field(frontmatter: str | None, key: str, value) -> str | None:
     """Generic helper to update or insert a frontmatter field."""
     if value is None or value == "" or value == []:
         return frontmatter
-    if isinstance(value, list):
-        value_str = "[" + ", ".join(map(str, value)) + "]"
-    else:
+    try:
+        # ``yaml.safe_dump`` ensures values with special characters are quoted
+        # properly for YAML frontmatter.
+        value_str = yaml.safe_dump(value, default_flow_style=True).strip()
+    except yaml.YAMLError:
         value_str = str(value)
     if not frontmatter:
         return f"{key}: {value_str}"


### PR DESCRIPTION
## Summary
- ensure facts are YAML-safe by quoting special characters when writing frontmatter
- add regression test covering facts with colons in frontmatter

## Testing
- `pip install -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893231ad50c83329c3058bc58ed48da