### PR TITLE
Fix pylint import errors for tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,3 @@
 [MASTER]
 ignore=tests
+init-hook='import sys, pathlib; sys.path.insert(0, str(pathlib.Path().resolve()/"src"))'


### PR DESCRIPTION
## Summary
- ensure Pylint can find project sources by adding src to PYTHONPATH

## Testing
- `pylint tests/test_ai_prompt_utils.py`
- `pylint tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689326f8001883328d4d9428c4d2c1ac