### PR TITLE
Sort imports across project

### DIFF
--- a/src/echo_journal/config.py
+++ b/src/echo_journal/config.py
@@ -1,8 +1,8 @@
 """Core application paths and configuration constants."""
 
+import os
 from importlib.resources import files
 from pathlib import Path
-import os
 
 from .settings_utils import load_settings
 

--- a/src/echo_journal/env_utils.py
+++ b/src/echo_journal/env_utils.py
@@ -6,7 +6,6 @@ import shlex
 from pathlib import Path
 from typing import Dict
 
-
 # Absolute path to the project's ``.env`` file. It can be overridden with the
 # ``ECHO_JOURNAL_ENV_PATH`` environment variable so that calls from any working
 # directory can locate the file.

--- a/src/echo_journal/file_utils.py
+++ b/src/echo_journal/file_utils.py
@@ -1,10 +1,10 @@
 """Utility functions for reading and parsing journal entries."""
 
-from pathlib import Path
 import json
 import re
-from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 import aiofiles
 import yaml

--- a/src/echo_journal/jellyfin_utils.py
+++ b/src/echo_journal/jellyfin_utils.py
@@ -5,7 +5,7 @@ import logging
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, AsyncIterator
+from typing import Any, AsyncIterator, Dict, List
 
 import httpx
 

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -9,24 +9,24 @@ import hmac
 import json
 import logging
 import os
-import time
+import re
 import secrets
+import time
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Dict
-import re
 from urllib.parse import urlparse
 
 import aiofiles
 import bleach
 import httpx
 import markdown
-import yaml
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request, Query
-from fastapi.responses import HTMLResponse, JSONResponse, Response, RedirectResponse
+import yaml
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.routing import Mount
@@ -34,22 +34,21 @@ from starlette.routing import Mount
 from . import config
 from .ai_prompt_utils import fetch_ai_prompt
 from .file_utils import (
-    safe_entry_path,
-    parse_entry,
-    read_existing_frontmatter,
-    split_frontmatter,
-    parse_frontmatter,
     format_weather,
-    weather_description,
     load_json_file,
+    parse_entry,
+    parse_frontmatter,
+    read_existing_frontmatter,
+    safe_entry_path,
+    split_frontmatter,
+    weather_description,
 )
 from .immich_utils import update_photo_metadata
 from .jellyfin_utils import update_media_metadata, update_song_metadata
-from .prompt_utils import generate_prompt, _choose_anchor, load_prompts
-from .settings_utils import load_settings, save_settings, SETTINGS_PATH
-from .weather_utils import build_frontmatter, time_of_day_label
 from .numbers_utils import fetch_date_fact
-
+from .prompt_utils import _choose_anchor, generate_prompt, load_prompts
+from .settings_utils import SETTINGS_PATH, load_settings, save_settings
+from .weather_utils import build_frontmatter, time_of_day_label
 
 # Provide pathlib.Path.is_relative_to on Python < 3.9
 if not hasattr(Path, "is_relative_to"):

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -119,13 +119,11 @@ def save_settings(values: Dict[str, Any], path: Path | None = None) -> Dict[str,
                 config_module = importlib.import_module("echo_journal.config")
                 importlib.reload(config_module)
                 try:
-                    from echo_journal import (  # pylint: disable=import-outside-toplevel
+                    from echo_journal import immich_utils, jellyfin_utils
+                    from echo_journal import (
                         main as main_module,
-                        prompt_utils,
-                        wordnik_utils,
-                        immich_utils,
-                        jellyfin_utils,
-                    )
+                    )  # pylint: disable=import-outside-toplevel
+                    from echo_journal import prompt_utils, wordnik_utils
 
                     if hasattr(main_module, "reload_from_config"):
                         main_module.reload_from_config()

--- a/src/echo_journal/weather_utils.py
+++ b/src/echo_journal/weather_utils.py
@@ -1,7 +1,7 @@
 """Helpers for building frontmatter with optional weather data."""
 
-from typing import Optional, Dict
 from datetime import datetime
+from typing import Dict, Optional
 
 import httpx
 import yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 """Test configuration to ensure modules see predictable paths."""
 
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -6,18 +6,18 @@
 #
 # pylint: disable=redefined-outer-name,too-many-lines,import-outside-toplevel,multiple-imports,wrong-import-order,unused-argument
 
+import base64
 import json
+import logging
 import os
 import shutil
 import sys
 import tempfile
-from datetime import datetime, date, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
-import base64
-import logging
-import httpx  # pylint: disable=import-error
 
 import aiofiles  # type: ignore  # pylint: disable=import-error
+import httpx  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error
 from fastapi.testclient import TestClient  # pylint: disable=import-error
 
@@ -53,15 +53,15 @@ sys.path.insert(0, str(ROOT / "src"))
 
 # Import the application after environment setup
 from echo_journal import ai_prompt_utils  # pylint: disable=wrong-import-position
-from echo_journal.file_utils import (  # pylint: disable=wrong-import-position
-    split_frontmatter,
-    parse_frontmatter,
-)
-from echo_journal import main  # type: ignore  # pylint: disable=wrong-import-position
-from echo_journal import weather_utils  # pylint: disable=wrong-import-position
 from echo_journal import immich_utils  # pylint: disable=wrong-import-position
 from echo_journal import jellyfin_utils  # pylint: disable=wrong-import-position
+from echo_journal import main  # type: ignore  # pylint: disable=wrong-import-position
 from echo_journal import numbers_utils  # pylint: disable=wrong-import-position
+from echo_journal import weather_utils  # pylint: disable=wrong-import-position
+from echo_journal.file_utils import (  # pylint: disable=wrong-import-position
+    parse_frontmatter,
+    split_frontmatter,
+)
 
 
 @pytest.fixture()
@@ -1264,6 +1264,7 @@ def test_basic_auth_required(monkeypatch):
     monkeypatch.setenv("BASIC_AUTH_USERNAME", "user")
     monkeypatch.setenv("BASIC_AUTH_PASSWORD", "pass")
     import importlib
+
     from echo_journal import config
 
     importlib.reload(config)
@@ -1298,6 +1299,7 @@ def test_basic_auth_malformed_headers_logged(monkeypatch, caplog, header):
     monkeypatch.setenv("BASIC_AUTH_USERNAME", "user")
     monkeypatch.setenv("BASIC_AUTH_PASSWORD", "pass")
     import importlib
+
     from echo_journal import config
 
     importlib.reload(config)
@@ -1322,7 +1324,8 @@ def test_settings_endpoints(tmp_path, monkeypatch):
     settings_file.write_text("FOO: baz\n", encoding="utf-8")
 
     import importlib
-    from echo_journal import settings_utils, config
+
+    from echo_journal import config, settings_utils
 
     monkeypatch.setattr(settings_utils, "SETTINGS_PATH", settings_file)
 

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -2,8 +2,8 @@
 
 # pylint: disable=protected-access
 
-from datetime import date
 import importlib
+from datetime import date
 
 from echo_journal import main
 


### PR DESCRIPTION
## Summary
- run isort to sort and format imports across the codebase

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932b53a6e88332bd3c90364bc4241a