### PR TITLE
docs: move frontmatter reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,45 +193,7 @@ Echo Journal's development roadmap is maintained in [ROADMAP.md](ROADMAP.md). Hi
 
 ## YAML Frontmatter Reference
 
-Each journal entry begins with a YAML block. These fields are parsed whenever an entry is saved or displayed.
-
-### Example
-
-```yaml
-location: Example Place
-weather: 18°C code 1
-save_time: Evening
-wotd: luminous
-wotd_def: emitting light
-category: Gratitude
-photos: []
-```
-
-### Field details
-
-| Field | Purpose | Application usage |
-| ----- | ------- | ----------------- |
-| `location` | Human readable label from browser geolocation. | Shown with a 📍 icon in archive and entry views. |
-| `weather` | Temperature and weather code from Open‑Meteo. | Parsed by `format_weather` to show an icon; codes are mapped to words for mouseover titles. |
-| `save_time` | Morning/Afternoon/Evening/Night recorded at save time. | Provides context for when the entry was written. |
-| `wotd` | Wordnik word of the day. | Displayed in the entry sidebar and as an icon in the archive list. |
-| `wotd_def` | Definition for the word of the day. | Shown alongside the word in entry views. |
-| `category` | Prompt category selected when saving. | Stored for filtering and prompt history. |
-| `photos` | List of photo objects from Immich, initially empty. | Adds a 📸 icon in the archive and shows thumbnails under the entry. |
-
-Additional keys may be introduced in future integrations (e.g., facts, mood tracking). Unknown keys are ignored.
-
-## Energy level mapping
-
-Energy selections from the UI are translated to integers before hitting `/api/new_prompt`.
-This allows the backend to score prompts based on numeric intensity.
-
-| Energy | Value |
-| ------ | ----- |
-| `drained` | 1 |
-| `low` | 2 |
-| `ok` | 3 |
-| `energized` | 4 |
+Details about the entry front matter and energy level mapping have moved to [docs/frontmatter.md](docs/frontmatter.md).
 
 ### Disabling integrations
 

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -1,0 +1,41 @@
+# YAML Frontmatter Reference
+
+Each journal entry begins with a YAML block. These fields are parsed whenever an entry is saved or displayed.
+
+## Example
+
+```yaml
+location: Example Place
+weather: 18°C code 1
+save_time: Evening
+wotd: luminous
+wotd_def: emitting light
+category: Gratitude
+photos: []
+```
+
+## Field details
+
+| Field | Purpose | Application usage |
+| ----- | ------- | ----------------- |
+| `location` | Human readable label from browser geolocation. | Shown with a 📍 icon in archive and entry views. |
+| `weather` | Temperature and weather code from Open‑Meteo. | Parsed by `format_weather` to show an icon; codes are mapped to words for mouseover titles. |
+| `save_time` | Morning/Afternoon/Evening/Night recorded at save time. | Provides context for when the entry was written. |
+| `wotd` | Wordnik word of the day. | Displayed in the entry sidebar and as an icon in the archive list. |
+| `wotd_def` | Definition for the word of the day. | Shown alongside the word in entry views. |
+| `category` | Prompt category selected when saving. | Stored for filtering and prompt history. |
+| `photos` | List of photo objects from Immich, initially empty. | Adds a 📸 icon in the archive and shows thumbnails under the entry. |
+
+Additional keys may be introduced in future integrations (e.g., facts, mood tracking). Unknown keys are ignored.
+
+## Energy level mapping
+
+Energy selections from the UI are translated to integers before hitting `/api/new_prompt`.
+This allows the backend to score prompts based on numeric intensity.
+
+| Energy | Value |
+| ------ | ----- |
+| `drained` | 1 |
+| `low` | 2 |
+| `ok` | 3 |
+| `energized` | 4 |


### PR DESCRIPTION
## Summary
- extract frontmatter and energy mapping details into docs/frontmatter.md
- replace README section with brief pointer to frontmatter docs

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `npm install`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932afe84888332ada4cca5a8711bf1