### PR TITLE
Sort imports for settings module

### DIFF
--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -119,11 +119,17 @@ def save_settings(values: Dict[str, Any], path: Path | None = None) -> Dict[str,
                 config_module = importlib.import_module("echo_journal.config")
                 importlib.reload(config_module)
                 try:
-                    from echo_journal import immich_utils, jellyfin_utils
                     from echo_journal import (
-                        main as main_module,
-                    )  # pylint: disable=import-outside-toplevel
-                    from echo_journal import prompt_utils, wordnik_utils
+                        immich_utils,
+                        jellyfin_utils,
+                    )
+                    from echo_journal import (
+                        main as main_module,  # pylint: disable=import-outside-toplevel
+                    )
+                    from echo_journal import (
+                        prompt_utils,
+                        wordnik_utils,
+                    )
 
                     if hasattr(main_module, "reload_from_config"):
                         main_module.reload_from_config()


### PR DESCRIPTION
## Summary
- group dynamic imports in `settings_utils` to satisfy import sorting

## Testing
- `python -m isort --profile black --check src/echo_journal/settings_utils.py src/echo_journal/main.py tests/test_endpoints.py`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932c9c8a6c8332aca7ab2edc700a7f