### PR TITLE
docs: add deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,50 +204,12 @@ toggleable here once implemented. Your choices are stored in `localStorage` and
 the server skips fetching data for any disabled integrations when building
 frontmatter.
 
-### Security considerations
+## Deployment
 
-- Set `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` before exposing the app
-  to the internet. Without these variables, anyone can access your journal.
-- Provide a valid contact email in `NOMINATIM_USER_AGENT` to comply with the
-  Nominatim usage policy; requests without contact info may be throttled or
-  rejected.
-- The `/api/settings` endpoint returns server configuration details for
-  convenience during development. Restrict it to trusted networks or run the
-  app behind a VPN or reverse proxy to avoid leaking secrets.
-- Outbound requests now include a 10-second timeout and prompt categories are
-  sanitized before saving or rendering, limiting the impact of malicious or
-  unexpected input.
-
-### Serving behind a VPN or reverse proxy
-
-Echo Journal binds to `127.0.0.1` by default so it's only reachable from the
-local machine. To make it available elsewhere, run it behind your VPN
-(e.g. WireGuard) or a reverse proxy such as Nginx or Caddy. The proxy can handle
-TLS termination and restrict access to known networks. Set
-`ECHO_JOURNAL_HOST=0.0.0.0` if the proxy needs to reach the app over the
-network.
-
-Example Nginx configuration terminating TLS and proxying requests:
-
-```nginx
-server {
-    listen 443 ssl;
-    server_name journal.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/journal.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/journal.example.com/privkey.pem;
-
-    location / {
-       proxy_pass http://127.0.0.1:8510;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-}
-```
-
-When exposing the app publicly, enable Basic Auth by setting
-`BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` so unauthenticated requests are
-rejected with a `401` response.
+Echo Journal is intended for use on trusted networks. When exposing the app
+elsewhere, run it behind a VPN or reverse proxy and enable HTTP Basic
+authentication. See the [deployment guide](docs/deployment.md) for detailed
+security notes and an example Nginx configuration.
 
 ## Testing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ optional HTTP Basic authentication that can be enabled by setting the
 those variables, there is no built‑in authentication. **Do not expose the
 application directly to the internet.** If you deploy publicly, enable Basic
 Auth and place the app behind a secure reverse proxy with additional access
-controls.
+controls. Refer to [docs/deployment.md](docs/deployment.md) for guidance on
+secure configuration and reverse proxy examples.
 
 ## Reporting a Vulnerability
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,32 @@
+# Deployment
+
+## Security
+
+- Set `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` before exposing the app to the internet. Without these variables, anyone can access your journal.
+- Provide a valid contact email in `NOMINATIM_USER_AGENT` to comply with the Nominatim usage policy; requests without contact info may be throttled or rejected.
+- The `/api/settings` endpoint returns server configuration details for convenience during development. Restrict it to trusted networks or run the app behind a VPN or reverse proxy to avoid leaking secrets.
+- Outbound requests include a 10-second timeout and prompt categories are sanitized before saving or rendering, limiting the impact of malicious or unexpected input.
+
+## Reverse Proxy
+
+Echo Journal binds to `127.0.0.1` by default so it's only reachable from the local machine. To make it available elsewhere, run it behind your VPN (e.g. WireGuard) or a reverse proxy such as Nginx or Caddy. The proxy can handle TLS termination and restrict access to known networks. Set `ECHO_JOURNAL_HOST=0.0.0.0` if the proxy needs to reach the app over the network.
+
+Example Nginx configuration terminating TLS and proxying requests:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name journal.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/journal.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/journal.example.com/privkey.pem;
+
+    location / {
+       proxy_pass http://127.0.0.1:8510;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+```
+
+When exposing the app publicly, enable Basic Auth by setting `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` so unauthenticated requests are rejected with a `401` response.


### PR DESCRIPTION
## Summary
- add `docs/deployment.md` with security notes and reverse proxy example
- reference deployment guide from README and security policy

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932d9ae0a48332822c6c9772ad7a8a