### PR TITLE
Sort imports with isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.isort]
+profile = "black"

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -31,8 +31,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.routing import Mount
 
-from .ai_prompt_utils import fetch_ai_prompt
 from . import config
+from .ai_prompt_utils import fetch_ai_prompt
 from .file_utils import (
     format_weather,
     load_json_file,

--- a/src/echo_journal/settings_utils.py
+++ b/src/echo_journal/settings_utils.py
@@ -1,9 +1,9 @@
 """Helpers for reading and writing ``settings.yaml`` files."""
 
 import importlib
-from importlib.resources import files
 import logging
 import os
+from importlib.resources import files
 from pathlib import Path
 from typing import Any, Dict
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -17,9 +17,9 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import aiofiles  # type: ignore  # pylint: disable=import-error
-from fastapi.testclient import TestClient  # pylint: disable=import-error
 import httpx  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error
+from fastapi.testclient import TestClient  # pylint: disable=import-error
 
 # Prepare required directories before importing the app
 ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- configure isort to use the black profile
- sort imports in main, settings utilities, and endpoint tests

## Testing
- `isort --check-only .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893305f1dc08332813cf2433198930a