### PR TITLE
Improve configuration typing and clean up utilities

### DIFF
--- a/src/echo_journal/config.py
+++ b/src/echo_journal/config.py
@@ -1,12 +1,20 @@
 """Core application paths and configuration constants."""
 
 import os
-from importlib.resources import files
 from pathlib import Path
+from typing import overload
 
 from .settings_utils import load_settings
 
 _SETTINGS = load_settings()
+
+
+@overload
+def _get_setting(key: str, default: str) -> str: ...
+
+
+@overload
+def _get_setting(key: str, default: None = None) -> str | None: ...
 
 
 def _get_setting(key: str, default: str | None = None) -> str | None:
@@ -24,11 +32,11 @@ def _get_setting(key: str, default: str | None = None) -> str | None:
     return value
 
 
-# Derive the application directory from the installed package location.  This
-# allows the code to run from arbitrary paths without requiring users to set
-# ``APP_DIR`` manually.  An environment variable can still override the value
-# for advanced scenarios such as tests or non-standard deployments.
-DEFAULT_APP_DIR = files("echo_journal").parent
+# Derive the application directory from this file location.  This allows the
+# code to run from arbitrary paths without requiring users to set ``APP_DIR``
+# manually.  An environment variable can still override the value for advanced
+# scenarios such as tests or non-standard deployments.
+DEFAULT_APP_DIR = Path(__file__).resolve().parent.parent
 # Allow overriding important paths via environment variables for easier testing
 # and deployment in restricted environments.
 APP_DIR = Path(_get_setting("APP_DIR", str(DEFAULT_APP_DIR)))

--- a/src/echo_journal/prompt_utils.py
+++ b/src/echo_journal/prompt_utils.py
@@ -160,7 +160,10 @@ async def generate_prompt(  # pylint: disable=too-many-locals,too-many-branches,
     prompts = await load_prompts()
     logger.debug("Loaded %d prompts", len(prompts) if isinstance(prompts, list) else 0)
     if not isinstance(prompts, list) or not prompts:
-        result = {"category": None, "prompt": "Prompts file not found"}
+        result: dict[str, object] = {
+            "category": None,
+            "prompt": "Prompts file not found",
+        }
         if debug:
             result["debug"] = {
                 "initial": [],

--- a/src/echo_journal/weather_utils.py
+++ b/src/echo_journal/weather_utils.py
@@ -56,6 +56,7 @@ async def build_frontmatter(
     lat = float(location.get("lat") or 0)
     lon = float(location.get("lon") or 0)
     label = location.get("label") or ""
+    weather_str: str | None
     if weather and "temperature" in weather and "code" in weather:
         weather_str = f"{weather['temperature']}°C code {int(weather['code'])}"
     else:

--- a/tests/test_jellyfin_utils.py
+++ b/tests/test_jellyfin_utils.py
@@ -11,7 +11,7 @@ class FakeClient:
     def __init__(self, items=None) -> None:
         """Initialize the fake client."""
         self.url = ""
-        self.calls = []
+        self.calls: list[dict | None] = []
         self.items = items
 
     async def __aenter__(self):


### PR DESCRIPTION
## Summary
- derive application directory from module path and add typed helper for settings lookups
- simplify settings loader and remove variable redefinition
- strengthen type safety across utilities and main application

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`
- `mypy src tests`


------
https://chatgpt.com/codex/tasks/task_e_6893331e70988332a1db4be8b17d2bbc