### PR TITLE
Fix missing mypy stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
     "bleach==6.2.0",
     "httpx==0.28.1",
     "pyyaml==6.0.2",
+    "types-aiofiles==24.1.0.20250801",
+    "types-PyYAML==6.0.12.20250516",
+    "types-bleach==6.2.0.20250514",
+    "types-Markdown==3.8.0.20250708",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add type stub packages for aiofiles, PyYAML, bleach, and Markdown

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`
- `mypy src/echo_journal`


------
https://chatgpt.com/codex/tasks/task_e_689335d1236883328350e7f9d131cb3b