### PR TITLE
chore: ignore missing mypy imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ where = ["src"]
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- ignore missing imports to avoid mypy stub errors

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`
- `mypy src/echo_journal --install-types --non-interactive`


------
https://chatgpt.com/codex/tasks/task_e_689343783d7c8332b246aeedba984f42