### PR TITLE
chore: enforce mypy type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,3 @@ where = ["src"]
 [tool.isort]
 profile = "black"
 
-[tool.mypy]
-ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- remove `ignore_missing_imports` so mypy uses real stubs

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_689346bb220c8332b8fd674c125dc675