### PR TITLE
Use secrets.choice for prompt selection

### DIFF
--- a/src/echo_journal/prompt_utils.py
+++ b/src/echo_journal/prompt_utils.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import logging
-import random
+import secrets
 from datetime import date
 
 import aiofiles
@@ -43,7 +43,7 @@ def _choose_anchor(mood: str | None, energy: int | None) -> str | None:
             if mood_l in {"drained", "self-doubt", "sad"}
             else ["micro", "soft"]
         )
-        anchor = random.choice(anchors)
+        anchor = secrets.choice(anchors)
         logger.debug(
             "Selected anchor '%s' for mood=%s energy=%s from %s",
             anchor,
@@ -77,7 +77,7 @@ def _choose_anchor(mood: str | None, energy: int | None) -> str | None:
         logger.debug("No anchor matches for mood=%s energy=%s", mood_l, energy)
         return None
 
-    anchor = random.choice(anchors)
+    anchor = secrets.choice(anchors)
     logger.debug(
         "Selected anchor '%s' for mood=%s energy=%s from %s",
         anchor,
@@ -197,7 +197,7 @@ async def generate_prompt(  # pylint: disable=too-many-locals,too-many-branches,
             result["debug"] = debug_info
         return result
 
-    chosen = random.choice(candidates)
+    chosen = secrets.choice(candidates)
     logger.debug("Chosen prompt: %s", chosen.get("id"))
     prompt_text = chosen.get("prompt", "")
     prompt_text = prompt_text.replace("{{weekday}}", weekday).replace(

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -27,7 +27,7 @@ def test_generate_prompt_uses_anchor(tmp_path, monkeypatch):
     pfile.write_text(content, encoding="utf-8")
     monkeypatch.setattr(prompt_utils, "PROMPTS_FILE", pfile)
     prompt_utils._prompts_cache = {"data": None, "mtime": None}
-    monkeypatch.setattr(prompt_utils.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(prompt_utils.secrets, "choice", lambda seq: seq[0])
 
     res = asyncio.run(prompt_utils.generate_prompt(mood="meh", energy=2))
 
@@ -55,7 +55,7 @@ def test_generate_prompt_debug(tmp_path, monkeypatch):
     pfile.write_text(content, encoding="utf-8")
     monkeypatch.setattr(prompt_utils, "PROMPTS_FILE", pfile)
     prompt_utils._prompts_cache = {"data": None, "mtime": None}
-    monkeypatch.setattr(prompt_utils.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(prompt_utils.secrets, "choice", lambda seq: seq[0])
 
     res = asyncio.run(prompt_utils.generate_prompt(mood="meh", energy=2, debug=True))
 
@@ -68,11 +68,11 @@ def test_generate_prompt_debug(tmp_path, monkeypatch):
 
 def test_choose_anchor_self_doubt(monkeypatch):
     """_choose_anchor prioritizes micro for self-doubt."""
-    monkeypatch.setattr(prompt_utils.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(prompt_utils.secrets, "choice", lambda seq: seq[0])
     assert prompt_utils._choose_anchor("self-doubt", 2) == "micro"
 
 
 def test_choose_anchor_joyful_high_energy(monkeypatch):
     """_choose_anchor can return strong for joyful mood."""
-    monkeypatch.setattr(prompt_utils.random, "choice", lambda seq: seq[-1])
+    monkeypatch.setattr(prompt_utils.secrets, "choice", lambda seq: seq[-1])
     assert prompt_utils._choose_anchor("joyful", 3) == "strong"


### PR DESCRIPTION
## Summary
- use `secrets.choice` instead of `random.choice` in `prompt_utils`
- update tests to monkeypatch `secrets.choice`

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934c81655c8332a05494aa569d3830