### PR TITLE
Exclude tests directory from Bandit scanning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
       # ----- Security -----
       - name: Run Bandit
-        run: bandit -r .
+        run: bandit -r . -x tests
 
       - name: Run pip-audit
         run: pip-audit


### PR DESCRIPTION
## Summary
- Prevent Bandit from checking `tests/` during CI

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934cb262248332b6c8ef9e976252cb