### PR TITLE
chore: bump setuptools build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=78.1.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary
- bump setuptools build requirement to 78.1.1 to address known vulnerabilities

## Testing
- `pip-audit`
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893542fef848332976e86af577054f3