### PR TITLE
ci: upgrade setuptools in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip "setuptools>=78.1.1"
           pip install pytest pytest-cov pylint black isort mypy bandit pip-audit
           pip install httpx fastapi starlette uvicorn aiofiles bleach markdown pyyaml
           pip install types-PyYAML types-aiofiles types-bleach types-Markdown


### PR DESCRIPTION
## Summary
- upgrade setuptools in CI workflow to >=78.1.1 for pip-audit

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`
- `pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_6893580d41dc83329e51f65193bb6495