### PR TITLE
Avoid empty photos field in frontmatter

### DIFF
--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -11,7 +11,6 @@ save_time: Evening
 wotd: luminous
 wotd_def: emitting light
 category: Gratitude
-photos: []
 ```
 
 ## Field details
@@ -24,7 +23,7 @@ photos: []
 | `wotd` | Wordnik word of the day. | Displayed in the entry sidebar and as an icon in the archive list. |
 | `wotd_def` | Definition for the word of the day. | Shown alongside the word in entry views. |
 | `category` | Prompt category selected when saving. | Stored for filtering and prompt history. |
-| `photos` | List of photo objects from Immich, initially empty. | Adds a 📸 icon in the archive and shows thumbnails under the entry. |
+| `photos` | List of photo objects from Immich, when available. | Adds a 📸 icon in the archive and shows thumbnails under the entry. |
 
 Additional keys may be introduced in future integrations (e.g., facts, mood tracking). Unknown keys are ignored.
 

--- a/src/echo_journal/weather_utils.py
+++ b/src/echo_journal/weather_utils.py
@@ -85,6 +85,4 @@ async def build_frontmatter(
                 if line.strip() and line.strip() != "..."
             )
             lines.append(f"wotd_def: {dumped}")
-    if integrations.get("immich", True):
-        lines.append("photos: []")
     return "\n".join(lines)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -393,7 +393,6 @@ def test_view_entry_uses_frontmatter(test_client):
         "---\n"
         "location: Testville\n"
         "weather: 12\u00b0C code 1\n"
-        "photos: []\n"
         "---\n"
         "# Prompt\nP\n\n# Entry\nE"
     )
@@ -504,20 +503,19 @@ def test_archive_filter_and_sort(test_client):
         "---\n"
         "location: Btown\n"
         "weather: 10\u00b0C code 1\n"
-        "photos: []\n"
         "---\n"
         "# Prompt\nP1\n\n# Entry\nE1"
     )
-    entry2 = (
-        "---\n"
-        "weather: 12\u00b0C code 2\n"
-        "photos: []\n"
-        "---\n"
-        "# Prompt\nP2\n\n# Entry\nE2"
-    )
+    entry2 = """---
+weather: 12°C code 2
+---
+# Prompt
+P2
+
+# Entry
+E2"""
     entry3 = """---
 location: Atown
-photos: []
 ---
 # Prompt
 P3
@@ -592,7 +590,6 @@ def test_view_entry_shows_wotd(test_client):
     content = """---
 wotd: luminous
 wotd_def: emitting light
-photos: []
 ---
 # Prompt
 P
@@ -611,7 +608,6 @@ def test_archive_shows_wotd_icon(test_client):
     content = """---
 wotd: zephyr
 wotd_def: gentle breeze
-photos: []
 ---
 # Prompt
 P


### PR DESCRIPTION
## Summary
- avoid adding `photos: []` when building frontmatter
- document photos as optional and update examples
- adjust endpoint tests to omit default `photos` field

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689357c303808332a25e93651a53e949