### PR TITLE
Handle missing Jinja2 dependency

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -78,7 +78,7 @@ jellyfin_logger: logging.Logger
 auth_logger: logging.Logger
 ai_logger: logging.Logger
 immich_logger: logging.Logger
-templates: Jinja2Templates
+templates: Jinja2Templates | None
 
 
 def _refresh_config_vars() -> None:
@@ -152,7 +152,18 @@ def _configure_mounts_and_templates() -> None:
         if isinstance(route, Mount) and route.path == "/static":
             app.routes.remove(route)
     app.mount("/static", StaticFiles(directory=config.STATIC_DIR), name="static")
-    templates = Jinja2Templates(directory=str(config.TEMPLATES_DIR))
+    try:
+        templates = Jinja2Templates(directory=str(config.TEMPLATES_DIR))
+    except AssertionError:
+        logging.getLogger(__name__).warning(
+            "Jinja2 is not installed; template rendering is disabled"
+        )
+
+        class _MissingTemplates:  # pragma: no cover - simple runtime guard
+            def TemplateResponse(self, *_args, **_kwargs) -> HTMLResponse:  # type: ignore[override]
+                raise RuntimeError("Jinja2 must be installed to render templates")
+
+        templates = _MissingTemplates()  # type: ignore[assignment]
 
 
 def reload_from_config() -> None:


### PR DESCRIPTION
## Summary
- Prevent startup crashes when Jinja2 is absent by warning and providing a runtime guard

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935e52f4388332a5b8cd90b04e99d6