### PR TITLE
Log missing date facts and add Numbers API retries

### DIFF
--- a/src/echo_journal/config.py
+++ b/src/echo_journal/config.py
@@ -59,6 +59,9 @@ NOMINATIM_USER_AGENT = _get_setting(
     "NOMINATIM_USER_AGENT", "EchoJournal/1.0 (contact@example.com)"
 )
 
+# Number of retry attempts for Numbers API requests.
+NUMBERS_API_RETRIES = int(_get_setting("NUMBERS_API_RETRIES", "0"))
+
 # File logging path - defaults to ``DATA_DIR/.logs/echo_journal.log`` but can
 # be overridden via the ``LOG_FILE`` environment variable.
 LOG_FILE = Path(_get_setting("LOG_FILE", str(DATA_DIR / ".logs" / "echo_journal.log")))


### PR DESCRIPTION
## Summary
- add fact logger and warn when the Numbers API returns no result
- allow configuring Numbers API retries and skipping via integration flag
- test Numbers API front matter behavior and logging

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935e469d8c8332ac33d6f1e68ed81c