### PR TITLE
Restore mood and energy selections on reload

### DIFF
--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -321,6 +321,8 @@ async def index(request: Request):  # pylint: disable=too-many-locals
         anchor = meta.get("anchor", "")
         wotd = meta.get("wotd", "")
         wotd_def = meta.get("wotd_def", "")
+        mood = meta.get("mood", "")
+        energy = meta.get("energy", "")
     else:
         prompt = ""
         category = ""
@@ -328,6 +330,8 @@ async def index(request: Request):  # pylint: disable=too-many-locals
         entry = ""
         wotd = ""
         wotd_def = ""
+        mood = ""
+        energy = ""
 
     gap = _days_since_last_entry(config.DATA_DIR, today)
     missing_yesterday = gap is None or gap > 1
@@ -357,6 +361,8 @@ async def index(request: Request):  # pylint: disable=too-many-locals
             "active_page": "home",
             "wotd": wotd,
             "wotd_def": wotd_def,
+            "mood": mood,
+            "energy": energy,
             "missing_yesterday": missing_yesterday,
             "integrations": integrations,
             "csrf_token": request.state.csrf_token,

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -27,20 +27,20 @@
     <legend class="sr-only">Mood and energy (optional)</legend>
     <label for="mood-select" class="sr-only">Mood</label>
     <select id="mood-select" class="border rounded px-2 py-1 text-sm">
-      <option value="">Mood</option>
-      <option value="sad">😔 Sad</option>
-      <option value="self-doubt">😶 Self-doubt</option>
-      <option value="meh">😐 Meh</option>
-      <option value="okay">😊 Okay</option>
-      <option value="joyful">😍 Joyful</option>
+      <option value="" {% if not mood %}selected{% endif %}>Mood</option>
+      <option value="sad" {% if mood == 'sad' %}selected{% endif %}>😔 Sad</option>
+      <option value="self-doubt" {% if mood == 'self-doubt' %}selected{% endif %}>😶 Self-doubt</option>
+      <option value="meh" {% if mood == 'meh' %}selected{% endif %}>😐 Meh</option>
+      <option value="okay" {% if mood == 'okay' %}selected{% endif %}>😊 Okay</option>
+      <option value="joyful" {% if mood == 'joyful' %}selected{% endif %}>😍 Joyful</option>
     </select>
     <label for="energy-select" class="sr-only">Energy</label>
     <select id="energy-select" class="border rounded px-2 py-1 text-sm">
-      <option value="">Energy</option>
-      <option value="drained">🪫 Drained</option>
-      <option value="low">😴 Low</option>
-      <option value="ok">🙂 OK</option>
-      <option value="energized">⚡ Energized</option>
+      <option value="" {% if not energy %}selected{% endif %}>Energy</option>
+      <option value="drained" {% if energy == 'drained' %}selected{% endif %}>🪫 Drained</option>
+      <option value="low" {% if energy == 'low' %}selected{% endif %}>😴 Low</option>
+      <option value="ok" {% if energy == 'ok' %}selected{% endif %}>🙂 OK</option>
+      <option value="energized" {% if energy == 'energized' %}selected{% endif %}>⚡ Energized</option>
     </select>
   </fieldset>
 </section>

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -96,6 +96,23 @@ def test_index_returns_page(test_client):
     assert "Echo Journal" in resp.text
 
 
+def test_mood_energy_prefilled_on_reload(test_client):
+    """Mood and energy selections persist when reloading an existing entry."""
+    today = date.today().isoformat()
+    file_path = main.DATA_DIR / f"{today}.md"
+    file_path.write_text(
+        "---\nmood: joyful\nenergy: energized\n---\n# Prompt\nA\n\n# Entry\nB",
+        encoding="utf-8",
+    )
+    try:
+        resp = test_client.get("/")
+        assert resp.status_code == 200
+        assert '<option value="joyful" selected>' in resp.text
+        assert '<option value="energized" selected>' in resp.text
+    finally:
+        file_path.unlink()
+
+
 def test_restart_notice_shown_when_yesterday_missing(test_client):
     """Index shows restart message when there's no entry for yesterday."""
     two_days_ago = (date.today() - timedelta(days=2)).isoformat()


### PR DESCRIPTION
## Summary
- Load stored mood and energy values when rendering today's entry
- Preselect mood and energy dropdowns based on saved journal metadata
- Test that mood and energy selections persist across reloads

## Testing
- `pip install .`
- `npm install`
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936495b0a48332a1a0cc5d58bcceac