### PR TITLE
feat: switch to useless facts api

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Journalling should not feel like a chore or a responsibility. I have bounced off
 - Stats and archive views for gentle pattern tracking.  
 
 **🔌 Optional integrations**  
-- **Wordnik** (word of the day), **Immich** (photos), **Jellyfin** (media history), **NumbersAPI** (Fact of the day).  
+- **Wordnik** (word of the day), **Immich** (photos), **Jellyfin** (media history), **Useless Facts** (random fact).
 - Per-browser toggles — nothing is forced, nothing runs you didn’t ask for.
 - See your day in context.
 

--- a/src/echo_journal/numbers_utils.py
+++ b/src/echo_journal/numbers_utils.py
@@ -1,4 +1,4 @@
-"""Helpers for fetching date facts from numbersapi.com."""
+"""Helpers for fetching random facts from uselessfacts.jsph.pl."""
 
 from datetime import date
 from typing import Optional
@@ -6,16 +6,16 @@ from typing import Optional
 import httpx
 
 
-async def fetch_date_fact(day: date) -> Optional[str]:
-    """Return a fact string for the given date.
+async def fetch_date_fact(_: date) -> Optional[str]:
+    """Return a random useless fact.
 
-    Uses numbersapi.com to fetch a trivia fact about the supplied date.
-    Returns ``None`` if the request fails or the response is malformed.
+    Fetches a random fact from ``uselessfacts.jsph.pl``. The ``date`` argument is
+    ignored. Returns ``None`` if the request fails or the response is malformed.
     """
-    url = f"https://numbersapi.com/{day.month}/{day.day}/date?json"
+    url = "https://uselessfacts.jsph.pl/api/v2/facts/random"
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, timeout=10)
+            resp = await client.get(url, params={"language": "en"}, timeout=10)
             resp.raise_for_status()
             data = resp.json()
             text = data.get("text")

--- a/tests/test_numbers_utils.py
+++ b/tests/test_numbers_utils.py
@@ -39,13 +39,12 @@ class FakeClient:
 
 
 def test_fetch_date_fact(monkeypatch):
-    """The request should use HTTPS and the ``?json`` flag."""
+    """The request should hit the useless facts API with language parameter."""
     client = FakeClient({"text": "a fact"})
     monkeypatch.setattr(nu.httpx, "AsyncClient", lambda: client)
 
     result = asyncio.run(nu.fetch_date_fact(date(2024, 1, 2)))
 
     assert result == "a fact"
-    assert client.captured["url"].startswith("https://")
-    assert client.captured["url"].endswith("/1/2/date?json")
-    assert client.captured["params"] is None
+    assert client.captured["url"] == "https://uselessfacts.jsph.pl/api/v2/facts/random"
+    assert client.captured["params"] == {"language": "en"}


### PR DESCRIPTION
## Summary
- fetch random facts from uselessfacts.jsph.pl instead of numbersapi
- document Useless Facts integration
- adjust tests for new fact source

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689366f4bd388332860fa2dcd4876fdc