### PR TITLE
fix: install package in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip "setuptools>=78.1.1"
+          pip install .
           pip install pytest pytest-cov pylint black isort mypy bandit pip-audit
-          pip install httpx fastapi starlette uvicorn aiofiles bleach markdown pyyaml
-          pip install types-PyYAML types-aiofiles types-bleach types-Markdown
 
       # ----- Lint & Style -----
       - name: Run Pylint


### PR DESCRIPTION
## Summary
- ensure CI installs echo-journal and dependencies via `pip install .`

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689369332dac833284c064d019a41ce2