### PR TITLE
Run mypy only on source and test files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
       # ----- Type Checking -----
       - name: Run mypy
-        run: mypy .
+        run: mypy src tests
 
       # ----- Security -----
       - name: Run Bandit


### PR DESCRIPTION
## Summary
- avoid mypy scanning build artifacts in CI by running it only on the source and test directories

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `mypy src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936b266b7c83329c38ecd371726ed3