### PR TITLE
Use client timezone offset for save_time

### DIFF
--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -19,7 +19,7 @@ category: Gratitude
 | ----- | ------- | ----------------- |
 | `location` | Human readable label from browser geolocation. | Shown with a 📍 icon in archive and entry views. |
 | `weather` | Temperature and weather code from Open‑Meteo. | Parsed by `format_weather` to show an icon; codes are mapped to words for mouseover titles. |
-| `save_time` | Morning/Afternoon/Evening/Night recorded at save time. | Provides context for when the entry was written. |
+| `save_time` | Morning/Afternoon/Evening/Night recorded at save time. | Provides context for when the entry was written. Uses the client `tz_offset` when supplied. |
 | `wotd` | Wordnik word of the day. | Displayed in the entry sidebar and as an icon in the archive list. |
 | `wotd_def` | Definition for the word of the day. | Shown alongside the word in entry views. |
 | `category` | Prompt category selected when saving. | Stored for filtering and prompt history. |

--- a/src/echo_journal/weather_utils.py
+++ b/src/echo_journal/weather_utils.py
@@ -72,7 +72,6 @@ async def build_frontmatter(
         lines.append(f"location: {label}")
     if weather_str:
         lines.append(f"weather: {weather_str}")
-    lines.append(f"save_time: {time_of_day_label()}")
     if wotd_word:
         lines.append(f"wotd: {wotd_word}")
         if wotd_def:

--- a/tests/test_weather_utils.py
+++ b/tests/test_weather_utils.py
@@ -73,7 +73,6 @@ def test_build_frontmatter(monkeypatch):
 
     monkeypatch.setattr(weather_utils, "fetch_weather", fake_fetch_weather)
     monkeypatch.setattr(weather_utils, "fetch_word_of_day", fake_wotd)
-    monkeypatch.setattr(weather_utils, "time_of_day_label", lambda: "Morning")
     fm = asyncio.run(
         weather_utils.build_frontmatter(
             {"lat": 1, "lon": 2, "label": "Town"},
@@ -99,7 +98,6 @@ def test_build_frontmatter_multiline_definition(monkeypatch):
 
     monkeypatch.setattr(weather_utils, "fetch_weather", fake_fetch_weather)
     monkeypatch.setattr(weather_utils, "fetch_word_of_day", fake_wotd)
-    monkeypatch.setattr(weather_utils, "time_of_day_label", lambda: "Morning")
 
     fm = asyncio.run(
         weather_utils.build_frontmatter(


### PR DESCRIPTION
## Summary
- adjust save_time based on client-provided tz_offset
- centralize save_time creation in save endpoint
- document tz_offset and add regression test

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936c337f5483329def10581f4188bf