### PR TITLE
Add docstring for FakeDatetime test helper

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -174,6 +174,8 @@ def test_save_entry_uses_timezone_offset(test_client, monkeypatch):
     """Timezone offset should adjust save_time label."""
 
     class FakeDatetime(datetime):
+        """Deterministic datetime for timezone tests."""
+
         @classmethod
         def utcnow(cls):
             return cls(2020, 1, 4, 15, 0, 0)


### PR DESCRIPTION
## Summary
- document FakeDatetime helper class used in timezone offset test

## Testing
- `pip install .`
- `npm install`
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936e958a948332a8b951b3b86fd2ab