### PR TITLE
Document FakeDatetime helper in endpoint tests

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -174,7 +174,7 @@ def test_save_entry_uses_timezone_offset(test_client, monkeypatch):
     """Timezone offset should adjust save_time label."""
 
     class FakeDatetime(datetime):
-        """Deterministic datetime for timezone tests."""
+        """Test helper returning a fixed UTC timestamp for deterministic saves."""
 
         @classmethod
         def utcnow(cls):


### PR DESCRIPTION
## Summary
- document FakeDatetime helper class used in timezone offset test

## Testing
- `pylint tests/test_endpoints.py`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893703d39d88332993efc269223591b