### PR TITLE
Send timezone offset with entries

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -10,6 +10,7 @@
   const getEnergyValue = (level) => energyLevels[level] || null;
   const defaultIntegrations = { wordnik: true, immich: true, jellyfin: true, fact: true, ai: true };
   const integrationSettings = { ...defaultIntegrations, ...(cfg.integrations || {}) };
+  const tz_offset = -new Date().getTimezoneOffset();
 
   async function fetchWeather(lat, lon) {
     try {
@@ -437,7 +438,18 @@
               'Content-Type': 'application/json',
               'X-CSRF-Token': cfg.csrfToken,
             },
-            body: JSON.stringify({ date, content, prompt, category, location, weather, mood, energy, integrations: integrationSettings })
+            body: JSON.stringify({
+              date,
+              content,
+              prompt,
+              category,
+              location,
+              weather,
+              mood,
+              energy,
+              tz_offset,
+              integrations: integrationSettings,
+            })
           });
 
           if (!response.ok) {


### PR DESCRIPTION
## Summary
- capture the browser timezone offset on the client
- include the timezone offset when saving entries so save_time matches the user's local time

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `npm run build:css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a1e67500833282567861854f6112