### PR TITLE
test: document FakeDatetime helper

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -227,6 +227,8 @@ def test_save_entry_records_afternoon(test_client, monkeypatch, payload, utc_tim
     """Saving at 3 PM local time records an Afternoon label."""
 
     class FakeDatetime(datetime):
+        """Provide a controllable datetime for tests."""
+
         @classmethod
         def now(cls, tz=None):
             if tz is None:


### PR DESCRIPTION
## Summary
- document FakeDatetime helper class in endpoint tests

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c14f0f048332b162fc1d2ce28261