### PR TITLE
Add debug logging for save_time frontmatter

### DIFF
--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -432,6 +432,7 @@
 
         const status = document.getElementById('save-status');
         try {
+          console.debug('Saving entry with tz_offset', tz_offset, 'client time', new Date().toString());
           const response = await fetch('/entry', {
             method: 'POST',
             headers: {
@@ -460,6 +461,7 @@
           }
 
           const result = await response.json();
+          console.debug('Save entry response', result);
           if (result.status === 'success') {
             status.textContent = 'Last saved: just now — Echo Journal';
             status.classList.remove('error-text');


### PR DESCRIPTION
## Summary
- add server-side logger capturing timezone offsets and computed save_time label
- add client console debug for timezone offset and save response

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d45e0e288332b7e7c384e62405f0