### PR TITLE
docs: add alpha deployment warning

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,7 @@
 # Deployment
 
+> **Warning:** Echo Journal is in an alpha state and should not be exposed directly to the public internet. If remote access is required, use a VPN, reverse proxy, or other access controls to restrict who can reach the service.
+
 ## Security
 
 - Set `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` before exposing the app to the internet. Without these variables, anyone can access your journal.


### PR DESCRIPTION
## Summary
- warn that Echo Journal is alpha and shouldn't be exposed directly to the internet
- suggest VPN, reverse proxy, or other access controls for remote access

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8` *(fails: Unable to import 'yaml', 'httpx')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_689481ff774c8332b1e81018739d8ce7