### PR TITLE
Add configurable location and weather integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Echo Journal is a minimalist FastAPI journaling app designed for **AuADHD minds*
 - Optional auto-enrichment (location, weather, media, photos, trivia).  
 - Stats and archive views for gentle pattern tracking.  
 
-**🔌 Optional integrations**  
-- **Wordnik** (word of the day), **Immich** (photos), **Jellyfin** (media history), **Useless Facts** (random fact).
+**🔌 Optional integrations**
+- **Wordnik** (word of the day), **Immich** (photos), **Jellyfin** (media history), **Useless Facts** (random fact), **Location**, **Weather**.
 - Per-browser toggles — nothing is forced, nothing runs you didn’t ask for.
 - See your day in context.
 
@@ -259,11 +259,10 @@ Details about the entry front matter and energy level mapping have moved to [doc
 ### Disabling integrations
 
 The web UI includes a **Settings** page where optional integrations can be
-toggled per browser. Uncheck Wordnik, Immich, or Jellyfin integrations to
-disable their metadata. A future "Fact of the Day" option will also be
-toggleable here once implemented. Your choices are stored in `localStorage` and
-the server skips fetching data for any disabled integrations when building
-frontmatter.
+toggled per browser. Uncheck Wordnik, Immich, Jellyfin, Location, Weather, or
+Fact integrations to disable their metadata. Your choices are stored in
+`localStorage` and the server skips fetching data for any disabled integrations
+when building frontmatter.
 
 ## Deployment
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,8 @@ On startup the application looks for a `settings.yaml` file in `<DATA_DIR>/.sett
 | `JELLYFIN_PAGE_SIZE` | Pagination size for Jellyfin API. | Default `200`. |
 | `JELLYFIN_PLAY_THRESHOLD` | Percent threshold for "played". | Default `90`. |
 | `NOMINATIM_USER_AGENT` | Identifies your app when calling the Nominatim reverse geocoding API. | Include contact info per the usage policy. |
+| `INTEGRATION_LOCATION` | Include geolocation data in entry frontmatter. | Default `true`. |
+| `INTEGRATION_WEATHER` | Include current weather in entry frontmatter. | Default `true`. |
 | `LOG_LEVEL` | Logging verbosity. | Default `DEBUG`. |
 | `LOG_FILE` | Path to log file. | Default `/journals/.logs/echo_journal.log`; if empty, logs to stderr. |
 | `LOG_MAX_BYTES` | Max size before log rotation. | Default `1,048,576`. |

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -15,3 +15,5 @@ JELLYFIN_URL: http://localhost:8096
 JELLYFIN_API_KEY: your-jellyfin-api-key
 JELLYFIN_USER_ID: your-jellyfin-user-id
 NOMINATIM_USER_AGENT: EchoJournal/1.0 (you@example.com)
+INTEGRATION_LOCATION: true
+INTEGRATION_WEATHER: true

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -345,6 +345,8 @@ async def index(request: Request):  # pylint: disable=too-many-locals
         "immich": settings.get("INTEGRATION_IMMICH", "true").lower() != "false",
         "jellyfin": settings.get("INTEGRATION_JELLYFIN", "true").lower() != "false",
         "fact": settings.get("INTEGRATION_FACT", "true").lower() != "false",
+        "location": settings.get("INTEGRATION_LOCATION", "true").lower() != "false",
+        "weather": settings.get("INTEGRATION_WEATHER", "true").lower() != "false",
     }
     integrations["ai"] = bool(config.OPENAI_API_KEY)
     if templates is None:

--- a/src/echo_journal/weather_utils.py
+++ b/src/echo_journal/weather_utils.py
@@ -56,11 +56,12 @@ async def build_frontmatter(
     lat = float(location.get("lat") or 0)
     lon = float(location.get("lon") or 0)
     label = location.get("label") or ""
-    weather_str: str | None
-    if weather and "temperature" in weather and "code" in weather:
-        weather_str = f"{weather['temperature']}°C code {int(weather['code'])}"
-    else:
-        weather_str = await fetch_weather(lat, lon)
+    weather_str: str | None = None
+    if integrations.get("weather", True):
+        if weather and "temperature" in weather and "code" in weather:
+            weather_str = f"{weather['temperature']}°C code {int(weather['code'])}"
+        else:
+            weather_str = await fetch_weather(lat, lon)
     wotd_word = wotd_def = None
     if integrations.get("wordnik", True):
         wotd = await fetch_word_of_day()
@@ -68,7 +69,7 @@ async def build_frontmatter(
             wotd_word, wotd_def = wotd
 
     lines = []
-    if label:
+    if integrations.get("location", True) and label:
         lines.append(f"location: {label}")
     if weather_str:
         lines.append(f"weather: {weather_str}")

--- a/static/echo_journal.js
+++ b/static/echo_journal.js
@@ -8,7 +8,15 @@
   const readonly = cfg.readonly === true || cfg.readonly === "true";
   const energyLevels = { drained: 1, low: 2, ok: 3, energized: 4 };
   const getEnergyValue = (level) => energyLevels[level] || null;
-  const defaultIntegrations = { wordnik: true, immich: true, jellyfin: true, fact: true, ai: true };
+  const defaultIntegrations = {
+    wordnik: true,
+    immich: true,
+    jellyfin: true,
+    fact: true,
+    ai: true,
+    location: true,
+    weather: true,
+  };
   const integrationSettings = { ...defaultIntegrations, ...(cfg.integrations || {}) };
   const tz_offset = -new Date().getTimezoneOffset();
 
@@ -51,7 +59,7 @@
   };
 
   async function fetchGeolocationDetails() {
-    if (!navigator.geolocation) return;
+    if (!navigator.geolocation || !integrationSettings.location) return;
 
     navigator.geolocation.getCurrentPosition(async (pos) => {
       const { latitude, longitude, accuracy } = pos.coords;
@@ -77,7 +85,7 @@
       }
 
       const weatherEl = document.getElementById('weather-display');
-      if (weatherEl) {
+      if (weatherEl && integrationSettings.weather) {
         const weather = await fetchWeather(latitude, longitude);
         if (weather) {
           weatherEl.dataset.temp = weather.temperature;
@@ -511,7 +519,22 @@
       });
     });
 
-    if (!readonly) {
+    const metaDetails = document.getElementById('meta-details');
+    if (metaDetails) {
+      if (!integrationSettings.location) {
+        const locEl = document.getElementById('location-display');
+        if (locEl) locEl.remove();
+      }
+      if (!integrationSettings.weather) {
+        const weatherEl = document.getElementById('weather-display');
+        if (weatherEl) weatherEl.remove();
+      }
+      if (!integrationSettings.location && !integrationSettings.weather) {
+        metaDetails.remove();
+      }
+    }
+
+    if (!readonly && integrationSettings.location) {
       fetchGeolocationDetails();
     }
   });

--- a/templates/echo_journal.html
+++ b/templates/echo_journal.html
@@ -87,11 +87,25 @@
     <button id="save-button" class="hidden block w-full max-w-sm mx-auto mt-3 bg-slate-500 text-white rounded-xl py-3 text-lg font-semibold shadow transition hover:bg-slate-600 hover:brightness-105 hover:shadow-lg dark:bg-gray-400 dark:hover:bg-slate-500" aria-label="Save entry">Save Entry</button>
   </section>
 
+  {% if integrations.location or integrations.weather %}
   <details id="meta-details" class="w-full mx-auto text-center mt-2 space-y-1 hidden">
-    <summary class="cursor-pointer font-semibold">Location &amp; Weather</summary>
+    <summary class="cursor-pointer font-semibold">
+      {% if integrations.location and integrations.weather %}
+      Location &amp; Weather
+      {% elif integrations.location %}
+      Location
+      {% else %}
+      Weather
+      {% endif %}
+    </summary>
+    {% if integrations.location %}
     <div id="location-display" class="text-sm text-gray-600 dark:text-gray-300 italic hidden"></div>
+    {% endif %}
+    {% if integrations.weather %}
     <div id="weather-display" class="text-sm text-gray-600 dark:text-gray-300 italic hidden"></div>
+    {% endif %}
   </details>
+  {% endif %}
 
     <footer class="w-full mx-auto mt-8 bg-gray-100 dark:bg-[#222] text-[clamp(0.9rem,0.8vw+0.8rem,1rem)] text-gray-500 dark:text-gray-400 text-center leading-snug tracking-wide" id="save-status" aria-live="polite" role="status">
     <img src="/static/icons/echo_journal_transparent_128x128.png" alt="Echo Journal logo" class="h-16 inline align-middle opacity-50 transition">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -64,6 +64,30 @@
             class="h-5 w-5"
           />
         </div>
+        <div class="meta-card flex items-center justify-between gap-4">
+          <label for="integration-location" class="flex items-center gap-2 cursor-pointer">
+            <span class="text-2xl">📍</span>
+            <span id="integration-location-label" class="text-sm">Location</span>
+          </label>
+          <input
+            type="checkbox"
+            id="integration-location"
+            aria-labelledby="integration-location-label"
+            class="h-5 w-5"
+          />
+        </div>
+        <div class="meta-card flex items-center justify-between gap-4">
+          <label for="integration-weather" class="flex items-center gap-2 cursor-pointer">
+            <span class="text-2xl">☁️</span>
+            <span id="integration-weather-label" class="text-sm">Weather</span>
+          </label>
+          <input
+            type="checkbox"
+            id="integration-weather"
+            aria-labelledby="integration-weather-label"
+            class="h-5 w-5"
+          />
+        </div>
       </div>
     </fieldset>
       <div id="settings-fields" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"></div>
@@ -137,6 +161,8 @@ document.addEventListener("DOMContentLoaded", () => {
         immich: 'INTEGRATION_IMMICH',
         jellyfin: 'INTEGRATION_JELLYFIN',
         fact: 'INTEGRATION_FACT',
+        location: 'INTEGRATION_LOCATION',
+        weather: 'INTEGRATION_WEATHER',
       };
     const envSettingCategories = {
       Paths: [

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -412,6 +412,44 @@ def test_weather_saved_when_provided(test_client):
     assert "..." not in frontmatter
 
 
+def test_location_disabled_in_frontmatter(test_client):
+    """Location is omitted when integration is disabled."""
+    payload = {
+        "date": "2021-01-02",
+        "content": "entry",
+        "prompt": "prompt",
+        "location": {"lat": 1, "lon": 2, "accuracy": 0, "label": "Town"},
+        "weather": {"temperature": 20, "code": 1},
+        "integrations": {"location": False},
+    }
+    resp = test_client.post("/entry", json=payload)
+    assert resp.status_code == 200
+    text = (main.DATA_DIR / "2021-01-02.md").read_text(encoding="utf-8")
+    frontmatter, _ = split_frontmatter(text)
+    assert frontmatter is not None
+    assert "location:" not in frontmatter
+    assert "weather: 20°C code 1" in frontmatter
+
+
+def test_weather_disabled_in_frontmatter(test_client):
+    """Weather is omitted when integration is disabled."""
+    payload = {
+        "date": "2021-01-03",
+        "content": "entry",
+        "prompt": "prompt",
+        "location": {"lat": 1, "lon": 2, "accuracy": 0, "label": "Town"},
+        "weather": {"temperature": 20, "code": 1},
+        "integrations": {"weather": False},
+    }
+    resp = test_client.post("/entry", json=payload)
+    assert resp.status_code == 200
+    text = (main.DATA_DIR / "2021-01-03.md").read_text(encoding="utf-8")
+    frontmatter, _ = split_frontmatter(text)
+    assert frontmatter is not None
+    assert "weather:" not in frontmatter
+    assert "location: Town" in frontmatter
+
+
 def test_mood_and_energy_saved(test_client):
     """Selected mood and energy values are stored in frontmatter."""
     payload = {


### PR DESCRIPTION
## Summary
- allow disabling location and weather integrations via `INTEGRATION_LOCATION` and `INTEGRATION_WEATHER`
- guard geolocation/weather features on the client and settings UI
- document new flags and cover disabled scenarios with tests

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6895d187fa7c8332a9dcc5a23ddb76f2