### PR TITLE
Rename random fact helper

### DIFF
--- a/BUGS_FIXED.md
+++ b/BUGS_FIXED.md
@@ -801,7 +801,7 @@ The following issues were identified and subsequently resolved.
      【F:src/echo_journal/env_utils.py†L10-L18】
 
 66. **Numbers API requests insecure and incorrectly formatted** (fixed)
-   - `fetch_date_fact` used HTTP and passed `json=True`, which could return
+   - `fetch_random_fact` used HTTP and passed `json=True`, which could return
      non‑JSON responses.
    - The function now uses HTTPS and appends the `?json` flag.
    - Fixed lines:

--- a/src/echo_journal/main.py
+++ b/src/echo_journal/main.py
@@ -45,7 +45,7 @@ from .file_utils import (
 )
 from .immich_utils import update_photo_metadata
 from .jellyfin_utils import update_media_metadata, update_song_metadata
-from .numbers_utils import fetch_date_fact
+from .numbers_utils import fetch_random_fact
 from .prompt_utils import _choose_anchor, generate_prompt, load_prompts
 from .settings_utils import SETTINGS_PATH, load_settings, save_settings
 from .weather_utils import build_frontmatter, time_of_day_label
@@ -544,7 +544,7 @@ async def save_entry(data: dict):  # pylint: disable=too-many-locals
         retries = config.NUMBERS_API_RETRIES
         fact = None
         for _ in range(retries + 1):
-            fact = await fetch_date_fact(fact_date)
+            fact = await fetch_random_fact(fact_date)
             if fact:
                 break
         if fact is None:

--- a/src/echo_journal/numbers_utils.py
+++ b/src/echo_journal/numbers_utils.py
@@ -6,11 +6,12 @@ from typing import Optional
 import httpx
 
 
-async def fetch_date_fact(_: date) -> Optional[str]:
+async def fetch_random_fact(_: date) -> Optional[str]:
     """Return a random useless fact.
 
-    Fetches a random fact from ``uselessfacts.jsph.pl``. The ``date`` argument is
-    ignored. Returns ``None`` if the request fails or the response is malformed.
+    Fetches a random fact from ``uselessfacts.jsph.pl``. The supplied
+    ``date`` argument is ignored. Returns ``None`` if the request fails or the
+    response is malformed.
     """
     url = "https://uselessfacts.jsph.pl/api/v2/facts/random"
     try:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -75,8 +75,8 @@ def test_client(tmp_path, monkeypatch):
     async def fake_fact(_):
         return "test fact"
 
-    monkeypatch.setattr(main, "fetch_date_fact", fake_fact)
-    monkeypatch.setattr(numbers_utils, "fetch_date_fact", fake_fact)
+    monkeypatch.setattr(main, "fetch_random_fact", fake_fact)
+    monkeypatch.setattr(numbers_utils, "fetch_random_fact", fake_fact)
     # ensure settings file exists in case other tests removed it
     main.SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
     if not main.SETTINGS_PATH.exists():
@@ -299,8 +299,8 @@ def test_fact_with_colon_is_yaml_safe(test_client, monkeypatch):
     async def colon_fact(_):
         return "mind-blowing fact: in 1970 something happened"
 
-    monkeypatch.setattr(main, "fetch_date_fact", colon_fact)
-    monkeypatch.setattr(numbers_utils, "fetch_date_fact", colon_fact)
+    monkeypatch.setattr(main, "fetch_random_fact", colon_fact)
+    monkeypatch.setattr(numbers_utils, "fetch_random_fact", colon_fact)
 
     payload = {"date": "2020-02-03", "content": "entry", "prompt": "prompt"}
     resp = test_client.post("/entry", json=payload)
@@ -326,8 +326,8 @@ def test_long_fact_not_truncated(test_client, monkeypatch):
     async def long_fact_fn(_):
         return long_fact
 
-    monkeypatch.setattr(main, "fetch_date_fact", long_fact_fn)
-    monkeypatch.setattr(numbers_utils, "fetch_date_fact", long_fact_fn)
+    monkeypatch.setattr(main, "fetch_random_fact", long_fact_fn)
+    monkeypatch.setattr(numbers_utils, "fetch_random_fact", long_fact_fn)
 
     payload = {"date": "2020-02-05", "content": "entry", "prompt": "prompt"}
     resp = test_client.post("/entry", json=payload)
@@ -346,8 +346,8 @@ def test_fact_unavailable_logs_warning(test_client, monkeypatch, caplog):
     async def none_fact(_):
         return None
 
-    monkeypatch.setattr(main, "fetch_date_fact", none_fact)
-    monkeypatch.setattr(numbers_utils, "fetch_date_fact", none_fact)
+    monkeypatch.setattr(main, "fetch_random_fact", none_fact)
+    monkeypatch.setattr(numbers_utils, "fetch_random_fact", none_fact)
 
     payload = {"date": "2020-02-04", "content": "entry", "prompt": "prompt"}
     with caplog.at_level(logging.WARNING, logger="ej.fact"):

--- a/tests/test_numbers_utils.py
+++ b/tests/test_numbers_utils.py
@@ -38,12 +38,12 @@ class FakeClient:
         return Response(self._data)
 
 
-def test_fetch_date_fact(monkeypatch):
+def test_fetch_random_fact(monkeypatch):
     """The request should hit the useless facts API with language parameter."""
     client = FakeClient({"text": "a fact"})
     monkeypatch.setattr(nu.httpx, "AsyncClient", lambda: client)
 
-    result = asyncio.run(nu.fetch_date_fact(date(2024, 1, 2)))
+    result = asyncio.run(nu.fetch_random_fact(date(2024, 1, 2)))
 
     assert result == "a fact"
     assert client.captured["url"] == "https://uselessfacts.jsph.pl/api/v2/facts/random"


### PR DESCRIPTION
## Summary
- rename `fetch_date_fact` to `fetch_random_fact`
- update imports, docstrings, and tests to reflect the random fact behaviour
- sync bug fix documentation with the new helper name

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895d8b164b88332b119b85be01061b1