### PR TITLE
feat: add multi-arch docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -31,6 +34,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             docker.io/eoghannirving/echo_journal:latest
             docker.io/eoghannirving/echo_journal:${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary
- enable QEMU emulation in Docker workflow
- build and push multi-arch images for amd64 and arm64

## Testing
- `pip install .`
- `npm install`
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895db5115cc8332b5bd79fc1cab395d