### PR TITLE
chore: add release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,11 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: 'Features'
+    labels: ['feature', 'enhancement']
+  - title: 'Fixes'
+    labels: ['bug', 'fix']
+  - title: 'Chores'
+    labels: ['chore']
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+exclude-labels: ['skip-changelog']

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, reopened, edited, labeled, unlabeled, synchronize, closed]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- configure Release Drafter with basic categories and template
- add workflow to update draft release on PR activity

## Testing
- `black .`
- `pylint $(git ls-files '*.py') --fail-under=8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895db5bf6948332bad536e64d9257d2