### PR TITLE
Fix time filter type handling in prompt selection

### DIFF
--- a/src/echo_journal/prompt_utils.py
+++ b/src/echo_journal/prompt_utils.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import secrets
 from datetime import date, datetime
+from collections.abc import Iterable
 
 import aiofiles
 import yaml
@@ -220,7 +221,10 @@ async def generate_prompt(  # pylint: disable=too-many-locals,too-many-branches,
 
     if time_label:
         candidates = [
-            p for p in candidates if not p.get("times") or time_label in p.get("times")
+            p
+            for p in candidates
+            if (times := p.get("times")) is None
+            or (isinstance(times, Iterable) and time_label in times)
         ]
         if debug:
             debug_info["after_time"] = [p.get("id") for p in candidates]


### PR DESCRIPTION
## Summary
- Ensure prompt time filtering handles missing "times" lists safely

## Testing
- `pylint $(git ls-files '*.py') --fail-under=8 | tail -n 20`
- `mypy src`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896123c202c83328f0e1aaa6aac8b59